### PR TITLE
feat(ftux): entire flow mostly functional

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/typography": "^0.5.9",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@types/debug": "^4.1.7",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.25",
     "@types/react-dom": "^18.0.9",
@@ -40,10 +41,12 @@
     "autoprefixer": "^10.4.13",
     "classnames": "^2.3.2",
     "date-fns": "^2.29.3",
+    "debug": "^4.3.4",
     "history": "^5.3.0",
     "husky": "^8.0.3",
     "jsdom": "^21.1.0",
     "lint-staged": "^13.1.0",
+    "nanoid": "^4.0.0",
     "postcss": "^8.4.21",
     "qrcode.react": "^3.1.0",
     "query-string": "^8.1.0",
@@ -62,5 +65,6 @@
     "vite": "^4.0.4",
     "vite-tsconfig-paths": "^4.0.5",
     "vitest": "^0.28.2"
-  }
+  },
+  "devDependencies": {}
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -32,11 +32,12 @@ import {
   DatabaseSettingsPage,
   CreateProjectPage,
   CreateProjectGitPage,
-  CreateProjectGitLayout,
+  CreateProjectLayout,
   CreateProjectAddKeyPage,
   CreateProjectGitPushPage,
   CreateProjectGitSettingsPage,
   CreateProjectGitStatusPage,
+  CreateProjectNamePage,
 } from "@app/ui";
 import * as routes from "@app/routes";
 
@@ -155,12 +156,12 @@ const appRoutes: RouteObject[] = [
       },
 
       {
-        path: routes.CREATE_PROJECT_PATH,
-        element: <CreateProjectPage />,
-      },
-      {
         path: routes.CREATE_PROJECT_ADD_KEY_PATH,
-        element: <CreateProjectGitLayout />,
+        element: (
+          <ElevateRequired>
+            <CreateProjectLayout />
+          </ElevateRequired>
+        ),
         children: [
           {
             index: true,
@@ -169,8 +170,18 @@ const appRoutes: RouteObject[] = [
         ],
       },
       {
+        path: routes.CREATE_PROJECT_ADD_NAME_PATH,
+        element: <CreateProjectLayout />,
+        children: [
+          {
+            index: true,
+            element: <CreateProjectNamePage />,
+          },
+        ],
+      },
+      {
         path: routes.CREATE_PROJECT_GIT_PATH,
-        element: <CreateProjectGitLayout />,
+        element: <CreateProjectLayout />,
         children: [
           {
             index: true,
@@ -191,6 +202,11 @@ const appRoutes: RouteObject[] = [
         ],
       },
     ],
+  },
+
+  {
+    path: routes.CREATE_PROJECT_PATH,
+    element: <CreateProjectPage />,
   },
 
   {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -10,6 +10,7 @@ import type { AppState } from "@app/types";
 import { resetReducer } from "@app/reset-store";
 import { TOKEN_NAME, ELEVATED_TOKEN_NAME } from "@app/token";
 import { THEME_NAME } from "@app/theme";
+import { REDIRECT_NAME } from "@app/redirect-path";
 
 import { sagas, reducers } from "./packages";
 
@@ -25,7 +26,7 @@ interface AppStore<State> {
 const persistConfig = {
   key: "root",
   storage,
-  whitelist: [TOKEN_NAME, ELEVATED_TOKEN_NAME, THEME_NAME],
+  whitelist: [TOKEN_NAME, ELEVATED_TOKEN_NAME, THEME_NAME, REDIRECT_NAME],
 };
 
 export function setupStore({ initState }: Props): AppStore<AppState> {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -4,8 +4,9 @@ import type { Middleware, Store } from "@reduxjs/toolkit";
 import { PersistPartial } from "redux-persist/es/persistReducer";
 import { persistStore, persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage"; // defaults to localStorage for web
-import { prepareStore } from "saga-query";
+import { BATCH, prepareStore } from "saga-query";
 
+import { createLog } from "@app/debug";
 import type { AppState } from "@app/types";
 import { resetReducer } from "@app/reset-store";
 import { TOKEN_NAME, ELEVATED_TOKEN_NAME } from "@app/token";
@@ -29,22 +30,24 @@ const persistConfig = {
   whitelist: [TOKEN_NAME, ELEVATED_TOKEN_NAME, THEME_NAME, REDIRECT_NAME],
 };
 
+const log = createLog("redux");
+
 export function setupStore({ initState }: Props): AppStore<AppState> {
   const middleware: Middleware[] = [];
 
   if (import.meta.env.VITE_DEBUG === "true") {
-    /* const logger = (store: any) => (next: any) => (action: any) => {
+    const logger = (store: any) => (next: any) => (action: any) => {
       if (action.type === BATCH) {
-        console.log('== BATCH ==');
+        log("== BATCH ==");
         action.payload.forEach(console.log);
-        console.log('== END BATCH ==');
+        log("== END BATCH ==");
       } else {
-        console.log('ACTION', action);
+        log("ACTION", action);
       }
       next(action);
-      console.log('NEXT STATE', store.getState());
+      log("NEXT STATE", store.getState());
     };
-    middleware.push(logger); */
+    middleware.push(logger);
   }
 
   const prepared = prepareStore({

--- a/src/auth/elevate.ts
+++ b/src/auth/elevate.ts
@@ -10,6 +10,8 @@ import { elevateToken, ElevateToken, ElevateTokenCtx } from "./token";
 import { AUTH_LOADER_ID } from "./loader";
 import { ThunkCtx, thunks } from "@app/api";
 
+export type ElevateCtx = ThunkCtx<ElevateToken>;
+
 export const elevate = thunks.create<ElevateToken>(
   "elevate",
   function* onElevate(ctx: ThunkCtx<ElevateToken>, next) {

--- a/src/auth/loader.ts
+++ b/src/auth/loader.ts
@@ -14,6 +14,8 @@ export const defaultAuthLoader = (l: Partial<AuthLoader> = {}): AuthLoader => ({
     error: "",
     code: 0,
     exception_context: {},
+    verified: false,
+    id: "",
     ...l.meta,
   },
   ...l,

--- a/src/auth/signup.ts
+++ b/src/auth/signup.ts
@@ -6,6 +6,7 @@ import {
   setLoaderError,
 } from "saga-query";
 
+import { createLog } from "@app/debug";
 import { AuthApiCtx, ThunkCtx, thunks } from "@app/api";
 import { CreateUserForm, CreateUserCtx, createUser } from "@app/users";
 
@@ -13,7 +14,8 @@ import { TokenCtx, createToken, elevateToken, ElevateTokenCtx } from "./token";
 import { AUTH_LOADER_ID } from "./loader";
 import { createOrganization, OrgCtx } from "@app/organizations";
 import { ApiGen } from "@app/types";
-import { elevate } from "./elevate";
+
+const log = createLog("signup");
 
 function* setAuthError(ctx: AuthApiCtx) {
   if (ctx.json.ok) {
@@ -33,7 +35,9 @@ export const signup = thunks.create<CreateUserForm>(
       createUser.run,
       createUser(ctx.payload),
     );
-    console.log(userCtx);
+
+    log(userCtx);
+
     if (!userCtx.json.ok) {
       yield call(setAuthError, userCtx);
       return;
@@ -48,7 +52,9 @@ export const signup = thunks.create<CreateUserForm>(
         makeCurrent: true,
       }),
     );
-    console.log(tokenCtx);
+
+    log(tokenCtx);
+
     if (!tokenCtx.json.ok) {
       yield call(setAuthError, tokenCtx);
       return;
@@ -58,7 +64,9 @@ export const signup = thunks.create<CreateUserForm>(
       createOrganization.run,
       createOrganization({ name: email }),
     );
-    console.log(orgCtx);
+
+    log(orgCtx);
+
     if (!orgCtx.json.ok) {
       yield call(setAuthError, orgCtx);
       return;
@@ -68,7 +76,8 @@ export const signup = thunks.create<CreateUserForm>(
       elevateToken.run,
       elevateToken({ username: email, password, otpToken: "" }),
     );
-    console.log(elevateCtx);
+
+    log(elevateCtx);
 
     yield put(
       setLoaderSuccess({

--- a/src/debug/index.ts
+++ b/src/debug/index.ts
@@ -1,0 +1,17 @@
+import debug from "debug";
+
+/**
+ * If you want permanent logging statements then use this function to create a logger.
+ *
+ * const log = createLog('projects');
+ * log('some logging statement');
+ *
+ * Then to see the log statements in the browser debugger, type this in the debugger:
+ *  localStorage.debug = 'app:*';
+ * // or localStorage.debug = 'app:projects'; to only see those log statements
+ *
+ * And then refresh the page.
+ */
+export const createLog = (namespace: string) => {
+  return debug(`app:${namespace}`);
+};

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -202,7 +202,7 @@ export const createDeployApp = api.post<CreateAppProps>(
 
 interface CreateAppOpProps {
   appId: string;
-  env: { [key: string]: string | boolean | number };
+  env: { [key: string]: string };
 }
 export type CreateAppOpCtx = DeployApiCtx<any, CreateAppOpProps>;
 export const createAppOperation = api.post<CreateAppOpProps>(

--- a/src/deploy/database-images/index.ts
+++ b/src/deploy/database-images/index.ts
@@ -1,0 +1,103 @@
+import { api, cacheTimer, combinePages, PaginateProps, thunks } from "@app/api";
+import { defaultEntity } from "@app/hal";
+import { createTable } from "@app/slice-helpers";
+import { AppState, DeployDatabaseImage } from "@app/types";
+import { createSelector } from "@reduxjs/toolkit";
+import { createReducerMap, mustSelectEntity } from "robodux";
+import { selectDeploy } from "../slice";
+
+export interface DeployDatabaseImageResponse {
+  id: number;
+  default: boolean;
+  description: string;
+  discoverable: boolean;
+  docker_repo: string;
+  type: string;
+  version: string;
+  visible: boolean;
+  created_at: string;
+  updated_at: string;
+  _type: "database_image";
+}
+
+export const deserializeDeployDatabaseImage = (
+  payload: DeployDatabaseImageResponse,
+): DeployDatabaseImage => {
+  return {
+    id: `${payload.id}`,
+    default: payload.default,
+    description: payload.description,
+    discoverable: payload.discoverable,
+    dockerRepo: payload.docker_repo,
+    type: payload.type,
+    version: payload.version,
+    visible: payload.visible,
+    createdAt: payload.created_at,
+    updatedAt: payload.updated_at,
+  };
+};
+
+export const defaultDeployDatabaseImage = (
+  db: Partial<DeployDatabaseImage> = {},
+): DeployDatabaseImage => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    default: false,
+    description: "",
+    discoverable: false,
+    dockerRepo: "",
+    type: "",
+    version: "",
+    visible: false,
+    createdAt: now,
+    updatedAt: now,
+    ...db,
+  };
+};
+
+export const DEPLOY_DATABASE_IMAGE_NAME = "databaseImages";
+const slice = createTable<DeployDatabaseImage>({
+  name: DEPLOY_DATABASE_IMAGE_NAME,
+});
+const { add: addDeployDatabaseImages } = slice.actions;
+
+export const hasDeployDatabaseImage = (a: DeployDatabaseImage) => a.id !== "";
+export const databaseImageReducers = createReducerMap(slice);
+const initApp = defaultDeployDatabaseImage();
+const must = mustSelectEntity(initApp);
+
+const selectors = slice.getSelectors(
+  (s: AppState) => selectDeploy(s)[DEPLOY_DATABASE_IMAGE_NAME],
+);
+export const selectDatabaseImageById = must(selectors.selectById);
+export const selectDatabaseImagesAsList = createSelector(
+  selectors.selectTableAsList,
+  (imgs) =>
+    imgs.sort((a, b) => {
+      const type = a.type.localeCompare(b.type);
+      if (type !== 0) {
+        return type;
+      }
+      return a.version.localeCompare(b.version);
+    }),
+);
+
+export const fetchDatabaseImages = api.get<PaginateProps>(
+  "/database_images?page=:page",
+  { saga: cacheTimer() },
+);
+
+export const fetchAllDatabaseImages = thunks.create(
+  "fetch-all-databases",
+  { saga: cacheTimer() },
+  combinePages(fetchDatabaseImages),
+);
+
+export const databaseImageEntities = {
+  database_image: defaultEntity({
+    id: "database_image",
+    deserialize: deserializeDeployDatabaseImage,
+    save: addDeployDatabaseImages,
+  }),
+};

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -6,3 +6,4 @@ export * from "./endpoint";
 export * from "./database";
 export * from "./service";
 export * from "./log-drain";
+export * from "./database-images";

--- a/src/deploy/stack/index.ts
+++ b/src/deploy/stack/index.ts
@@ -82,6 +82,17 @@ export const selectStacksAsOptions = createSelector(
     });
   },
 );
+export const selectStackPublicDefault = createSelector(
+  selectStacksAsList,
+  (stacks) => {
+    if (stacks.length === 0) {
+      return initStack;
+    }
+
+    // find first public stack
+    return stacks.find((s) => s.public) || initStack;
+  },
+);
 export const hasDeployStack = (s: DeployStack) => s.organizationId !== "";
 export const stackReducers = createReducerMap(slice);
 

--- a/src/deploy/state.ts
+++ b/src/deploy/state.ts
@@ -5,6 +5,10 @@ import { stackReducers, stackEntities } from "./stack";
 import { environmentReducers, environmentEntities } from "./environment";
 import { endpointReducers, endpointEntities } from "./endpoint";
 import { databaseEntities, databaseReducers } from "./database";
+import {
+  databaseImageEntities,
+  databaseImageReducers,
+} from "./database-images";
 import { logDrainEntities, logDrainReducers } from "./log-drain";
 import { serviceEntities, serviceReducers } from "./service";
 
@@ -16,6 +20,7 @@ const allReducers: any[] = [
   databaseReducers,
   logDrainReducers,
   serviceReducers,
+  databaseImageReducers,
 ];
 
 const rootReducer = combineReducers(
@@ -36,4 +41,5 @@ export const entities = {
   ...databaseEntities,
   ...logDrainEntities,
   ...serviceEntities,
+  ...databaseImageEntities,
 };

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -1,0 +1,178 @@
+import { nanoid } from "nanoid";
+import {
+  all,
+  call,
+  put,
+  select,
+  setLoaderError,
+  setLoaderStart,
+  setLoaderSuccess,
+} from "saga-query";
+
+import { createLog } from "@app/debug";
+import { ThunkCtx, thunks } from "@app/api";
+import {
+  CreateAppCtx,
+  CreateAppOpCtx,
+  createAppOperation,
+  createDeployApp,
+  createDeployEnvironment,
+  CreateEnvCtx,
+  hasDeployApp,
+  hasDeployEnvironment,
+  provisionDatabase,
+  ProvisionDatabaseCtx,
+  selectAppById,
+  selectEnvironmentByName,
+} from "@app/deploy";
+import { ApiGen, DeployApp, DeployEnvironment } from "@app/types";
+
+interface CreateProjectProps {
+  name: string;
+  stackId: string;
+  orgId: string;
+}
+
+const log = createLog("project");
+
+export const createProject = thunks.create<CreateProjectProps>(
+  "create-project",
+  function* (ctx: ThunkCtx<CreateProjectProps>, next): ApiGen {
+    if (!ctx.payload.stackId) {
+      setLoaderError({ id: ctx.key, message: "stack cannot be empty" });
+      return;
+    }
+
+    if (!ctx.payload.name) {
+      setLoaderError({ id: ctx.key, message: "name cannot be empty" });
+      return;
+    }
+
+    yield put(setLoaderStart({ id: ctx.key }));
+
+    const env: DeployEnvironment = yield select(selectEnvironmentByName, {
+      handle: ctx.payload.name,
+    });
+
+    let envId = "";
+    if (hasDeployEnvironment(env)) {
+      log("environment already exists, continuing", env);
+      envId = env.id;
+    } else {
+      log("environment doesn't exist, creating");
+      const envCtx: CreateEnvCtx = yield call(
+        createDeployEnvironment.run,
+        createDeployEnvironment(ctx.payload),
+      );
+
+      if (!envCtx.json.ok) {
+        yield put(
+          setLoaderError({ id: ctx.key, message: envCtx.json.data.message }),
+        );
+        return;
+      }
+
+      log(envCtx);
+      envId = envCtx.json.data.id;
+    }
+
+    const appCtx: CreateAppCtx = yield call(
+      createDeployApp.run,
+      createDeployApp({ name: ctx.payload.name, envId }),
+    );
+
+    if (!appCtx.json.ok) {
+      yield put(
+        setLoaderError({
+          id: ctx.key,
+          meta: { envId },
+          message: appCtx.json.data.message,
+        }),
+      );
+      return;
+    }
+
+    log(appCtx);
+    const appId = appCtx.json.data.id;
+
+    yield put(
+      setLoaderSuccess({
+        id: ctx.key,
+        meta: { envId, appId },
+      }),
+    );
+    yield next();
+  },
+);
+
+export interface TextVal<
+  M extends { [key: string]: string } = { [key: string]: string },
+> {
+  key: string;
+  value: string;
+  meta?: M;
+}
+
+export interface CreateProjectSettingsProps {
+  appId: string;
+  envId: string;
+  dbs: TextVal<{ id: string }>[];
+  envs: TextVal[];
+  cmds: TextVal[];
+}
+
+export const deployProject = thunks.create<CreateProjectSettingsProps>(
+  "project-deploy",
+  function* (ctx: ThunkCtx<CreateProjectSettingsProps>, next) {
+    const { appId, envId, dbs, envs } = ctx.payload;
+    const id = ctx.name;
+    yield put(setLoaderStart({ id }));
+
+    const app: DeployApp = yield select(selectAppById, { id: appId });
+    if (!hasDeployApp(app)) {
+      const message = `no app found with id ${appId}, cannot deploy project`;
+      log(message);
+      yield put(setLoaderError({ id, message }));
+      return;
+    }
+
+    if (!envId) {
+      const message = "envId cannot be empty, cannot deploy project";
+      log(message);
+      yield put(setLoaderError({ id, message }));
+      return;
+    }
+
+    const dbCtx: ProvisionDatabaseCtx[] = yield all(
+      dbs
+        .filter((db) => db.meta?.id)
+        .map((db) => {
+          const handle = `${app.handle}-${db.key}-${nanoid(5)}`;
+          return call(
+            provisionDatabase.run,
+            provisionDatabase({
+              handle: handle.toLocaleLowerCase(),
+              type: db.key,
+              envId,
+              databaseImageId: db.meta?.id || "",
+            }),
+          );
+        }),
+    );
+
+    log(dbCtx);
+
+    const configCtx: CreateAppOpCtx = yield call(
+      createAppOperation.run,
+      createAppOperation({
+        appId,
+        env: envs.reduce((acc, env) => ({ ...acc, [env.key]: env.value }), {}),
+      }),
+    );
+
+    log(configCtx);
+
+    yield next();
+    yield put(setLoaderSuccess({ id }));
+  },
+);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -86,13 +86,17 @@ export const CREATE_PROJECT_PATH = "/create";
 export const createProjectUrl = () => CREATE_PROJECT_PATH;
 export const CREATE_PROJECT_ADD_KEY_PATH = "/create/ssh";
 export const createProjectAddKeyUrl = () => CREATE_PROJECT_ADD_KEY_PATH;
+export const CREATE_PROJECT_ADD_NAME_PATH = "/create/name";
+export const createProjectAddNameUrl = () => CREATE_PROJECT_ADD_NAME_PATH;
 
 export const CREATE_PROJECT_GIT_PATH = "/create/git";
 export const createProjectGitUrl = () => CREATE_PROJECT_GIT_PATH;
-export const CREATE_PROJECT_GIT_PUSH_PATH = "/create/git/push";
-export const createProjectGitPushUrl = () => CREATE_PROJECT_GIT_PUSH_PATH;
-export const CREATE_PROJECT_GIT_SETTINGS_PATH = "/create/git/settings";
-export const createProjectGitSettingsUrl = () =>
-  CREATE_PROJECT_GIT_SETTINGS_PATH;
-export const CREATE_PROJECT_GIT_STATUS_PATH = "/create/git/status";
-export const createProjectGitStatusUrl = () => CREATE_PROJECT_GIT_STATUS_PATH;
+export const CREATE_PROJECT_GIT_PUSH_PATH = "/create/git/:appId/push";
+export const createProjectGitPushUrl = (appId: string) =>
+  `/create/git/${appId}/push`;
+export const CREATE_PROJECT_GIT_SETTINGS_PATH = "/create/git/:appId/settings";
+export const createProjectGitSettingsUrl = (appId: string) =>
+  `/create/git/${appId}/settings`;
+export const CREATE_PROJECT_GIT_STATUS_PATH = "/create/git/:appId/status";
+export const createProjectGitStatusUrl = (appId: string) =>
+  `/create/git/${appId}/status`;

--- a/src/ssh-keys/index.ts
+++ b/src/ssh-keys/index.ts
@@ -1,0 +1,22 @@
+import { authApi } from "@app/api";
+
+export const fetchSSHKeys = authApi.get<{ userId: string }>(
+  "/users/:userId/ssh_keys",
+  authApi.cache(),
+);
+
+export const addSSHKey = authApi.post<{
+  name: string;
+  key: string;
+  userId: string;
+}>("/users/:userId/ssh_keys", function* (ctx, next) {
+  const body = {
+    name: ctx.payload.name,
+    ssh_public_key: ctx.payload.key,
+  };
+  ctx.request = ctx.req({
+    body: JSON.stringify(body),
+  });
+
+  yield next();
+});

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -1,3 +1,5 @@
+import { LinkResponse } from "./hal";
+
 export type ProvisionableStatus =
   | "pending"
   | "provisioning"
@@ -110,7 +112,7 @@ export interface DeployStack extends Timestamps {
   organizationId: string;
 }
 
-type OperationStatus = "queued" | "running" | "failed" | "succeeded";
+export type OperationStatus = "queued" | "running" | "failed" | "succeeded";
 
 export interface DeployOperation extends Timestamps {
   id: string;
@@ -120,7 +122,7 @@ export interface DeployOperation extends Timestamps {
   status: OperationStatus;
   gitRef: string;
   dockerRef: string;
-  containerCount: string;
+  containerCount: number;
   encryptedEnvJsonNew: string;
   destinationRegion: string;
   cancelled: boolean;
@@ -139,9 +141,12 @@ export interface DeployOperation extends Timestamps {
 export interface DeployOperationResponse {
   id: number;
   type: string;
-  status: "queued" | "running" | "failed" | "succeeded";
+  status: OperationStatus;
   user_name: string;
   updated_at: string;
+  _links: {
+    resource: LinkResponse;
+  };
 }
 
 export interface DeployDisk extends Timestamps {
@@ -174,6 +179,17 @@ export interface DeployDatabase extends Provisionable, Timestamps {
   type: string;
   disk: DeployDisk | null;
   serviceId: string;
+}
+
+export interface DeployDatabaseImage extends Timestamps {
+  id: string;
+  default: boolean;
+  description: string;
+  discoverable: boolean;
+  dockerRepo: string;
+  type: string;
+  version: string;
+  visible: boolean;
 }
 
 export interface ContainerProfile {

--- a/src/types/loader.ts
+++ b/src/types/loader.ts
@@ -4,6 +4,8 @@ export interface AuthLoaderMessage {
   error: string;
   code: number;
   exception_context: { [key: string]: any };
+  verified: boolean;
+  id: string;
 }
 
 export type AuthLoader = LoadingItemState<AuthLoaderMessage>;

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -5,6 +5,7 @@ import type { MapEntity } from "./helpers";
 import type {
   DeployApp,
   DeployDatabase,
+  DeployDatabaseImage,
   DeployDisk,
   DeployEndpoint,
   DeployEnvironment,
@@ -78,6 +79,7 @@ export interface DeployState {
   stacks: MapEntity<DeployStack>;
   disks: MapEntity<DeployDisk>;
   databases: MapEntity<DeployDatabase>;
+  databaseImages: MapEntity<DeployDatabaseImage>;
   services: MapEntity<DeployService>;
   logDrains: MapEntity<DeployLogDrain>;
 }

--- a/src/ui/layouts/auth-required.tsx
+++ b/src/ui/layouts/auth-required.tsx
@@ -1,5 +1,5 @@
-import { Outlet, Navigate } from "react-router-dom";
-import { useSelector } from "react-redux";
+import { Outlet, Navigate, useLocation } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { useLoader } from "saga-query/react";
 
 import { loginUrl } from "@app/routes";
@@ -7,12 +7,23 @@ import { selectIsUserAuthenticated } from "@app/token";
 import { fetchCurrentToken } from "@app/auth";
 
 import { Loading } from "../shared";
+import { useEffect } from "react";
+import { setRedirectPath } from "@app/redirect-path";
 
 export const AuthRequired = () => {
   const loader = useLoader(fetchCurrentToken);
   const isAuthenticated = useSelector(selectIsUserAuthenticated);
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const authed = loader.isLoading || isAuthenticated;
 
-  if (!(loader.isLoading || isAuthenticated)) {
+  useEffect(() => {
+    if (!authed) {
+      dispatch(setRedirectPath(location.pathname));
+    }
+  }, [authed]);
+
+  if (!authed) {
     return <Navigate to={loginUrl()} />;
   }
 

--- a/src/ui/layouts/elevate-required.tsx
+++ b/src/ui/layouts/elevate-required.tsx
@@ -12,7 +12,11 @@ import { fetchCurrentToken } from "@app/auth";
 
 import { Loading } from "../shared";
 
-export const ElevateRequired = () => {
+export const ElevateRequired = ({
+  children,
+}: {
+  children?: React.ReactNode;
+}) => {
   const loader = useLoader(fetchCurrentToken);
   const isAuthenticated = useSelector(selectIsUserAuthenticated);
   const isElevatedTokenValid = useSelector(selectIsElevatedTokenValid);
@@ -34,9 +38,5 @@ export const ElevateRequired = () => {
     return <Navigate to={elevateUrl(location.pathname)} replace />;
   }
 
-  return (
-    <div>
-      <Outlet />
-    </div>
-  );
+  return <div>{children ? children : <Outlet />}</div>;
 };

--- a/src/ui/pages/create-project.tsx
+++ b/src/ui/pages/create-project.tsx
@@ -1,26 +1,36 @@
 import { createProjectGitUrl } from "@app/routes";
-import { ListingPageLayout } from "../layouts";
 import { ButtonLink, IconSmallArrowRight, tokens, Box } from "../shared";
 
 export const CreateProjectPage = () => {
   return (
-    <ListingPageLayout>
-      <div className="flex justify-center container">
-        <div style={{ width: 500 }}>
-          <div className="text-center">
-            <h1 className={tokens.type.h1}>Create an Environment</h1>
-            <p className="my-4 text-gray-600">
-              Choose a deployment type for your app to get started.
-            </p>
+    <div className="flex flex-col flex-1">
+      <main className="flex-1">
+        <div className="py-6">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8">
+            <div className="py-4">
+              <div className="flex justify-center container">
+                <div style={{ width: 500 }}>
+                  <div className="text-center">
+                    <h1 className={tokens.type.h1}>Create an Environment</h1>
+                    <p className="my-4 text-gray-600">
+                      Choose a deployment type for your app to get started.
+                    </p>
+                  </div>
+                  <Box>
+                    <ButtonLink
+                      to={createProjectGitUrl()}
+                      className="font-bold"
+                    >
+                      Deploy your code
+                      <IconSmallArrowRight className="ml-2" />
+                    </ButtonLink>
+                  </Box>
+                </div>
+              </div>
+            </div>
           </div>
-          <Box>
-            <ButtonLink to={createProjectGitUrl()} className="font-bold">
-              Deploy your code
-              <IconSmallArrowRight className="ml-2" />
-            </ButtonLink>
-          </Box>
         </div>
-      </div>
-    </ListingPageLayout>
+      </main>
+    </div>
   );
 };

--- a/src/ui/pages/elevate.tsx
+++ b/src/ui/pages/elevate.tsx
@@ -55,6 +55,11 @@ export const ElevatePage = () => {
           <h2 className="mt-6 text-center text-3xl font-bold text-gray-900">
             Elevate token
           </h2>
+          <p>
+            We require a short-lived elevated token before allowing changes to
+            authentication credentials (i.e. changing password, adding pubkey,
+            disabling 2FA).
+          </p>
         </div>
 
         <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-md">
@@ -113,6 +118,7 @@ export const ElevatePage = () => {
                     autoComplete="off"
                     id="input-2fa"
                     className="flex-1 outline-0 py-1 bg-transparent"
+                    autoFocus
                   />
                 </FormGroup>
               ) : null}
@@ -122,7 +128,6 @@ export const ElevatePage = () => {
                   isLoading={loader.isLoading}
                   disabled={loader.isLoading}
                   type="submit"
-                  variant="primary"
                   layout="block"
                   size="lg"
                 >
@@ -136,71 +141,3 @@ export const ElevatePage = () => {
     </div>
   );
 };
-
-/*
-<div className="bg-white/5 shadow-md rounded-lg">
-  <FormGroup className="px-6 h-14 flex items-center border-b border-white/5">
-    <label htmlFor="input-email" className="w-20 text-sm">
-      Email
-    </label>
-
-    <input
-      name="email"
-      type="email"
-      disabled
-      value={user.email}
-      autoComplete="username"
-      autoFocus
-      data-testid="input-email"
-      id="input-email"
-      className="flex-1 outline-0 py-1 bg-transparent disabled:cursor-not-allowed text-white/20"
-    />
-  </FormGroup>
-
-  <FormGroup className="px-6 h-14 flex items-center">
-    <label htmlFor="input-password" className="w-20 text-sm">
-      Password
-    </label>
-    <input
-      name="password"
-      type="password"
-      value={password}
-      onChange={(e) => setPassword(e.currentTarget.value)}
-      autoComplete="current-password"
-      data-testid="input-password"
-      id="input-password"
-      className="flex-1 outline-0 py-1 bg-transparent"
-    />
-  </FormGroup>
-
-  {requireOtp && (
-    <FormGroup className="px-6 h-14 flex items-center border-t border-white/5">
-      <label htmlFor="input-2fa" className="w-20 text-sm">
-        2FA Token
-      </label>
-      <input
-        type="number"
-        value={otpToken}
-        onChange={(e) => setOtpToken(e.currentTarget.value)}
-        autoComplete="off"
-        autoFocus
-        data-testid="input-2fa"
-        id="input-2fa"
-        className="flex-1 outline-0 py-1 bg-transparent"
-      />
-    </FormGroup>
-  )}
-</div>
-
-<div className="flex flex-col justify-between mt-9 mb-6">
-  <Button
-    isLoading={loader.isLoading}
-    disabled={loader.isLoading}
-    type="submit"
-    variant="success"
-    className="h-12 rounded-lg"
-  >
-    Log in
-  </Button>
-</div>
-*/

--- a/src/ui/pages/login.tsx
+++ b/src/ui/pages/login.tsx
@@ -27,6 +27,7 @@ import {
   LoggedInBanner,
   IconExclamation,
 } from "../shared";
+import { resetRedirectPath, selectRedirectPath } from "@app/redirect-path";
 
 export const LoginPage = () => {
   const dispatch = useDispatch();
@@ -37,6 +38,7 @@ export const LoginPage = () => {
   const [password, setPassword] = useState<string>("");
   const [requireOtp, setRequireOtp] = useState<boolean>(false);
   const loader = useSelector(selectAuthLoader);
+  const redirectPath = useSelector(selectRedirectPath);
 
   const invitationRequest = useSelector(selectInvitationRequest);
   const invitation = useSelector(selectPendingInvitation);
@@ -51,7 +53,8 @@ export const LoginPage = () => {
     if (invitationRequest.invitationId) {
       navigate(acceptInvitationWithCodeUrl(invitationRequest));
     } else {
-      navigate(homeUrl());
+      navigate(redirectPath || homeUrl());
+      dispatch(resetRedirectPath());
     }
   });
 

--- a/src/ui/pages/verify-email.tsx
+++ b/src/ui/pages/verify-email.tsx
@@ -5,9 +5,10 @@ import { useLoader, useLoaderSuccess } from "saga-query/react";
 
 import { verifyEmail } from "@app/auth";
 import { selectJWTToken } from "@app/token";
-import { createOrgUrl } from "@app/routes";
+import { homeUrl } from "@app/routes";
 
 import { Loading, Progress, ResendVerificationEmail } from "../shared";
+import { resetRedirectPath, selectRedirectPath } from "@app/redirect-path";
 
 export const VerifyEmailPage = () => {
   const dispatch = useDispatch();
@@ -15,6 +16,7 @@ export const VerifyEmailPage = () => {
   const params = useParams();
   const navigate = useNavigate();
   const verifyEmailLoader = useLoader(verifyEmail);
+  const redirectPath = useSelector(selectRedirectPath);
 
   useEffect(() => {
     if (params.verificationCode && params.verificationId && user.id) {
@@ -28,7 +30,8 @@ export const VerifyEmailPage = () => {
   }, [params.verificationId, params.verificationCode, user.id]);
 
   useLoaderSuccess(verifyEmailLoader, () => {
-    navigate(createOrgUrl());
+    navigate(redirectPath || homeUrl());
+    dispatch(resetRedirectPath());
   });
 
   if (verifyEmailLoader.isLoading) {

--- a/src/ui/shared/add-ssh-key.tsx
+++ b/src/ui/shared/add-ssh-key.tsx
@@ -1,0 +1,79 @@
+import { addSSHKey } from "@app/ssh-keys";
+import { selectCurrentUserId } from "@app/users";
+import { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useLoader, useLoaderSuccess } from "saga-query/react";
+import { BannerMessages } from "./banner-messages";
+import { Button } from "./button";
+import { FormGroup } from "./form-group";
+import { Input } from "./input";
+import { tokens } from "./tokens";
+
+export const AddSSHKeyForm = ({
+  onSuccess = () => {},
+}: {
+  onSuccess?: () => void;
+}) => {
+  const userId = useSelector(selectCurrentUserId);
+  const dispatch = useDispatch();
+  const [key, setKey] = useState("");
+  const [name, setName] = useState("");
+  const loader = useLoader(addSSHKey);
+
+  const addKey = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    dispatch(addSSHKey({ userId, name, key }));
+  };
+
+  useLoaderSuccess(loader, () => {
+    onSuccess();
+  });
+
+  return (
+    <div>
+      <h2 className={tokens.type.h3}>Public SSH Key</h2>
+      <p className="text-gray-600 mb-2">
+        Copy the contents of the file <code>$HOME/.ssh/id_rsa.pub</code> then
+        paste here. Need Help? View Docs
+      </p>
+
+      <form onSubmit={addKey}>
+        <FormGroup label="Name" htmlFor="name" feedbackVariant="info">
+          <Input
+            name="name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.currentTarget.value)}
+            autoComplete="username"
+          />
+          <div>Pick a name that helps you remember this key</div>
+        </FormGroup>
+
+        <FormGroup
+          label="Public Key"
+          htmlFor="public-key"
+          feedbackVariant="info"
+        >
+          <textarea
+            className={tokens.type.textarea}
+            value={key}
+            onChange={(e) => setKey(e.currentTarget.value)}
+          />
+        </FormGroup>
+
+        {loader.isError ? <BannerMessages {...loader} /> : null}
+
+        <div>
+          <Button
+            type="submit"
+            className="w-full mt-2"
+            disabled={!(key && name)}
+            isLoading={loader.isLoading}
+          >
+            Save Key
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/src/ui/shared/banner-messages.tsx
+++ b/src/ui/shared/banner-messages.tsx
@@ -1,12 +1,24 @@
-export const BannerMessages = (loader: {
+import cn from "classnames";
+
+import { variantToColor } from "@app/status-variant";
+
+export const BannerMessages = (props: {
   isSuccess: boolean;
   isError: boolean;
   message: string;
+  className?: string;
 }) => {
+  const cls = "p-4 border rounded text-xs";
   return (
-    <div>
-      {loader.isSuccess ? <div>Success! {loader.message}</div> : null}
-      {loader.isError ? <div>{loader.message}</div> : null}
+    <div className={props.className}>
+      {props.isSuccess ? (
+        <div className={cn(cls, variantToColor("success"))}>
+          Success! {props.message}
+        </div>
+      ) : null}
+      {props.isError ? (
+        <div className={cn(cls, variantToColor("error"))}>{props.message}</div>
+      ) : null}
     </div>
   );
 };

--- a/src/ui/shared/modal-portal.tsx
+++ b/src/ui/shared/modal-portal.tsx
@@ -1,17 +1,20 @@
 import { useSelector, useDispatch } from "react-redux";
 
+import { createLog } from "@app/debug";
 import {
   selectCurrentModal,
   selectModalProps,
   closeCurrentModal,
 } from "@app/modal";
 
+const log = createLog("modal-portal");
+
 export const ModalPortal = () => {
   const dispatch = useDispatch();
   const modal = useSelector(selectCurrentModal);
   const modalProps = useSelector(selectModalProps);
   const closeModal = () => dispatch(closeCurrentModal());
-  console.log(modalProps, closeModal);
+  log(modalProps, closeModal);
 
   switch (modal) {
     default:

--- a/src/ui/shared/tokens.ts
+++ b/src/ui/shared/tokens.ts
@@ -34,6 +34,7 @@ export const tokens = {
     "info normal": "text-gray-600",
     textarea:
       "appearance-none block px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-emerald-500 focus:border-emerald-500 sm:text-sm w-full h-20",
+    pre: "p-4 bg-black rounded text-white overflow-x-scroll",
   },
 
   spacing: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -650,6 +650,13 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
   integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
 
+"@types/debug@^4.1.7":
+  version "4.1.7"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
+  integrity sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==
+  dependencies:
+    "@types/ms" "*"
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -684,6 +691,11 @@
   dependencies:
     expect "^29.0.0"
     pretty-format "^29.0.0"
+
+"@types/ms@*":
+  version "0.7.31"
+  resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
+  integrity sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==
 
 "@types/node@*":
   version "18.11.9"
@@ -2214,6 +2226,11 @@ nanoid@^3.3.4:
   version "3.3.4"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
   integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
+
+nanoid@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-4.0.0.tgz#6e144dee117609232c3f415c34b0e550e64999a5"
+  integrity sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==
 
 node-releases@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
A user can now traverse the entire flow of our new first time user experience.

`/create` -> new endpoint created for ftux flow

A user can:
- signup / login / be logged in
- add ssh key
- create an environment and an app
- deploy app
- create and provision (n) databases
- configure environment variables
- monitor all operations

What's left:
- Check for scan operation
- Add service commands
- Add endpoints
- Show logs after op completed
- Deployment failed screen
- Review deployment screen

https://user-images.githubusercontent.com/1940365/217033912-dbc4bf54-1788-4d6b-bce8-f2e37a0d0868.mp4


