### PR TITLE
Code scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "redux-batched-actions": "^0.5.0",
     "redux-persist": "^6.0.0",
     "rome": "^11.0.0",
-    "saga-query": "^5.1.0",
+    "saga-query": "^6.1.0",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
     "vite": "^4.0.4",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -14,6 +14,7 @@ import {
   setLoaderError,
   all,
   setLoaderSuccess,
+  LoaderCtx,
 } from "saga-query";
 import type { ApiCtx, Next, PipeCtx } from "saga-query";
 
@@ -147,7 +148,7 @@ authApi.use(tokenMdw);
 authApi.use(elevatedTokenMdw);
 authApi.use(fetcher());
 
-export interface ThunkCtx<P = any, D = any> extends PipeCtx<P> {
+export interface ThunkCtx<P = any, D = any> extends PipeCtx<P>, LoaderCtx<P> {
   actions: Action[];
   json: D | null;
 }

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -39,7 +39,7 @@ export function setupStore({ initState }: Props): AppStore<AppState> {
     const logger = (store: any) => (next: any) => (action: any) => {
       if (action.type === BATCH) {
         log("== BATCH ==");
-        action.payload.forEach(console.log);
+        action.payload.forEach(log);
         log("== END BATCH ==");
       } else {
         log("ACTION", action);

--- a/src/date/index.ts
+++ b/src/date/index.ts
@@ -1,9 +1,13 @@
 import { format, formatRelative } from "date-fns";
 
-export const prettyDateTime = (dateStr: string) => {
+export const prettyDateTime = (dateStr: string = "") => {
+  return format(new Date(dateStr), "yyyy-MM-dd hh:mm:ss aaa");
+};
+
+export const prettyDate = (dateStr: string = "") => {
   return format(new Date(dateStr), "yyyy-MM-dd");
 };
 
-export const prettyDateRelative = (dateStr: string) => {
+export const prettyDateRelative = (dateStr: string = "") => {
   return formatRelative(new Date(dateStr), new Date());
 };

--- a/src/deploy/code-scan-result/index.ts
+++ b/src/deploy/code-scan-result/index.ts
@@ -1,0 +1,21 @@
+import { api, cacheTimer } from "@app/api";
+import { LinkResponse } from "@app/types";
+
+export interface DeployCodeScanResponse {
+  id: number;
+  aptible_yml_present: boolean;
+  dockerfile_present: boolean;
+  procfile_present: boolean;
+  _links: {
+    self: LinkResponse;
+    app: LinkResponse;
+    operation: LinkResponse;
+  };
+  _type: "code_scan_result";
+}
+
+export const fetchCodeScanResult = api.get<{ id: string }>(
+  "/code_scan_results/:id",
+  { saga: cacheTimer() },
+  api.cache(),
+);

--- a/src/deploy/database-images/index.ts
+++ b/src/deploy/database-images/index.ts
@@ -89,7 +89,7 @@ export const fetchDatabaseImages = api.get<PaginateProps>(
 );
 
 export const fetchAllDatabaseImages = thunks.create(
-  "fetch-all-databases",
+  "fetch-all-database-images",
   { saga: cacheTimer() },
   combinePages(fetchDatabaseImages),
 );

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -6,7 +6,6 @@ import {
   setLoaderSuccess,
 } from "saga-query";
 
-import { createLog } from "@app/debug";
 import { defaultEntity, extractIdFromLink } from "@app/hal";
 import type {
   AppState,
@@ -31,13 +30,11 @@ import {
   mustSelectEntity,
 } from "@app/slice-helpers";
 
-import { deserializeOperation } from "../operation";
+import { deserializeDeployOperation } from "../operation";
 import { deserializeDisk } from "../disk";
 import { selectDeploy } from "../slice";
 import { createSelector } from "@reduxjs/toolkit";
 import { findEnvById, selectEnvironments } from "../environment";
-
-const log = createLog("database");
 
 export interface DeployDatabaseResponse {
   id: string;
@@ -81,7 +78,7 @@ export const deserializeDeployDatabase = (
     serviceId: extractIdFromLink(links.service),
     disk: embedded.disk ? deserializeDisk(embedded.disk) : null,
     lastOperation: embedded.last_operation
-      ? deserializeOperation(embedded.last_operation)
+      ? deserializeDeployOperation(embedded.last_operation)
       : null,
   };
 };

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -1,12 +1,26 @@
 import { api } from "@app/api";
-import type { DeployOperation, OperationStatus } from "@app/types";
-import { createAction } from "@reduxjs/toolkit";
+import {
+  defaultEntity,
+  extractIdFromLink,
+  extractResourceNameFromLink,
+} from "@app/hal";
+import {
+  createReducerMap,
+  createTable,
+  mustSelectEntity,
+} from "@app/slice-helpers";
+import type {
+  AppState,
+  DeployOperation,
+  LinkResponse,
+  OperationStatus,
+} from "@app/types";
+import { createAction, createSelector } from "@reduxjs/toolkit";
 import { poll } from "saga-query";
+import { selectDeploy } from "../slice";
 
 export interface DeployOperationResponse {
   id: string;
-  resource_id: number;
-  resource_type: string;
   type: string;
   status: OperationStatus;
   created_at: string;
@@ -27,18 +41,61 @@ export interface DeployOperationResponse {
   user_email: string;
   user_name: string;
   env: string;
+  _links: {
+    account: LinkResponse;
+    code_scan_result: LinkResponse;
+    ephemeral_sessions: LinkResponse;
+    logs: LinkResponse;
+    resource: LinkResponse;
+    self: LinkResponse;
+    ssh_portal_connections: LinkResponse;
+    user: LinkResponse;
+  };
 }
 
-export const deserializeOperation = (
+export const defaultDeployOperation = (
+  op: Partial<DeployOperation> = {},
+): DeployOperation => {
+  const now = new Date().toISOString();
+  return {
+    id: "",
+    environmentId: "",
+    codeScanResultId: "",
+    resourceId: "",
+    resourceType: "",
+    type: "",
+    status: "queued",
+    createdAt: now,
+    updatedAt: now,
+    gitRef: "",
+    dockerRef: "",
+    containerCount: 0,
+    encryptedEnvJsonNew: "",
+    destinationRegion: "",
+    cancelled: false,
+    aborted: false,
+    automated: false,
+    immediate: false,
+    provisionedIops: 0,
+    ebsVolumeType: "",
+    encryptedStackSettings: "",
+    instanceProfile: "",
+    userName: "",
+    userEmail: "",
+    env: "",
+    ...op,
+  };
+};
+
+export const deserializeDeployOperation = (
   payload: DeployOperationResponse,
-): DeployOperation | null => {
-  if (!payload) {
-    return null;
-  }
+): DeployOperation => {
   return {
     id: payload.id,
-    resourceId: payload.resource_id,
-    resourceType: payload.resource_type,
+    environmentId: extractIdFromLink(payload._links.account),
+    codeScanResultId: extractIdFromLink(payload._links.code_scan_result),
+    resourceId: extractIdFromLink(payload._links.resource),
+    resourceType: extractResourceNameFromLink(payload._links.resource),
     type: payload.type,
     status: payload.status,
     createdAt: payload.created_at,
@@ -62,10 +119,67 @@ export const deserializeOperation = (
   };
 };
 
+export const DEPLOY_OP_NAME = "operations";
+const slice = createTable<DeployOperation>({ name: DEPLOY_OP_NAME });
+const { add: addDeployOperations } = slice.actions;
+export const hasDeployOperation = (a: DeployOperation) => a.id !== "";
+export const opReducers = createReducerMap(slice);
+
+const initOp = defaultDeployOperation();
+const must = mustSelectEntity(initOp);
+
+const selectors = slice.getSelectors(
+  (s: AppState) => selectDeploy(s)[DEPLOY_OP_NAME],
+);
+export const selectOperationById = must(selectors.selectById);
+const { selectTableAsList } = selectors;
+export const selectOperationsAsList = createSelector(selectTableAsList, (ops) =>
+  ops.sort((a, b) => {
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
+  }),
+);
+
+export const selectOperationsByEnvId = createSelector(
+  selectOperationsAsList,
+  (_: AppState, p: { envId: string }) => p.envId,
+  (ops, envId) => ops.filter((op) => op.environmentId === envId),
+);
+
+export const selectOperationsByAppId = createSelector(
+  selectOperationsAsList,
+  (_: AppState, p: { appId: string }) => p.appId,
+  (ops, appId) =>
+    ops.filter((op) => op.resourceType === "apps" && op.resourceId === appId),
+);
+
+export const selectLatestScanOp = createSelector(
+  selectOperationsByAppId,
+  (ops) => ops.find((op) => op.type === "scan_code") || initOp,
+);
+
+export const selectLatestSucceessScanOp = createSelector(
+  selectOperationsByAppId,
+  (ops) =>
+    ops.find((op) => op.type === "scan_code" && op.status === "succeeded") ||
+    initOp,
+);
+
+export const selectLatestDeployOp = createSelector(
+  selectOperationsByAppId,
+  (ops) => ops.find((op) => op.type === "deploy") || initOp,
+);
+
 export const cancelEnvOperationsPoll = createAction("cancel-env-ops-poll");
 
 export const pollEnvOperations = api.get<{ envId: string }>(
   "/accounts/:envId/operations",
   { saga: poll(5 * 1000, `${cancelEnvOperationsPoll}`) },
-  api.cache(),
 );
+
+export const opEntities = {
+  operation: defaultEntity({
+    id: "operation",
+    deserialize: deserializeDeployOperation,
+    save: addDeployOperations,
+  }),
+};

--- a/src/deploy/state.ts
+++ b/src/deploy/state.ts
@@ -11,6 +11,7 @@ import {
 } from "./database-images";
 import { logDrainEntities, logDrainReducers } from "./log-drain";
 import { serviceEntities, serviceReducers } from "./service";
+import { opEntities, opReducers } from "./operation";
 
 const allReducers: any[] = [
   appReducers,
@@ -21,6 +22,7 @@ const allReducers: any[] = [
   logDrainReducers,
   serviceReducers,
   databaseImageReducers,
+  opReducers,
 ];
 
 const rootReducer = combineReducers(
@@ -42,4 +44,5 @@ export const entities = {
   ...logDrainEntities,
   ...serviceEntities,
   ...databaseImageEntities,
+  ...opEntities,
 };

--- a/src/hal/index.test.ts
+++ b/src/hal/index.test.ts
@@ -1,0 +1,57 @@
+import { extractResourceNameFromLink, extractIdFromLink } from "./index";
+
+describe("extractIdFromLink", () => {
+  it("should safely handle null values", () => {
+    const actual = extractIdFromLink(null);
+    expect(actual).toEqual("");
+  });
+
+  it("should safely handle when there is a malformed url", () => {
+    const actual = extractIdFromLink({
+      href: "/wow",
+    });
+    expect(actual).toEqual("wow");
+  });
+
+  it("should safely handle when there is a malformed url with no `/`", () => {
+    const actual = extractIdFromLink({
+      href: "wow",
+    });
+    expect(actual).toEqual("wow");
+  });
+
+  it("should extract resource name from url", () => {
+    const actual = extractIdFromLink({
+      href: "https://api.aptible.com/apps/123",
+    });
+    expect(actual).toEqual("123");
+  });
+});
+
+describe("extractResourceNameFromLink", () => {
+  it("should safely handle null values", () => {
+    const actual = extractResourceNameFromLink(null);
+    expect(actual).toEqual("");
+  });
+
+  it("should safely handle when there is a malformed url", () => {
+    const actual = extractResourceNameFromLink({
+      href: "/wow",
+    });
+    expect(actual).toEqual("");
+  });
+
+  it("should safely handle when there is a malformed url with no `/`", () => {
+    const actual = extractIdFromLink({
+      href: "wow",
+    });
+    expect(actual).toEqual("wow");
+  });
+
+  it("should extract resource name from url", () => {
+    const actual = extractResourceNameFromLink({
+      href: "https://api.aptible.com/apps/123",
+    });
+    expect(actual).toEqual("apps");
+  });
+});

--- a/src/hal/index.ts
+++ b/src/hal/index.ts
@@ -17,7 +17,9 @@ import type { DeployApiCtx } from "@app/api";
   /([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})/,
 ); */
 
-export function extractIdFromLink(relation: { href: string } | null) {
+export function extractIdFromLink(
+  relation: { href: string } | null | undefined,
+) {
   if (!relation?.href) {
     return "";
   }
@@ -26,6 +28,17 @@ export function extractIdFromLink(relation: { href: string } | null) {
   return exec[0] || ''; */
   const segments = relation.href.split("/");
   return segments[segments.length - 1];
+}
+
+export function extractResourceNameFromLink(
+  resource: { href: string } | null | undefined,
+) {
+  if (!resource?.href) {
+    return "";
+  }
+
+  const res = resource.href.split("/");
+  return res[res.length - 2] || "";
 }
 
 export const ENTITIES_NAME = "entities";

--- a/src/hal/index.ts
+++ b/src/hal/index.ts
@@ -13,21 +13,14 @@ import type {
 } from "@app/types";
 import type { DeployApiCtx } from "@app/api";
 
-/* const uuidRe = new RegExp(
-  /([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})/,
-); */
-
 export function extractIdFromLink(
   relation: { href: string } | null | undefined,
 ) {
   if (!relation?.href) {
     return "";
   }
-  /* const exec = uuidRe.exec(url);
-  if (!exec) return '';
-  return exec[0] || ''; */
   const segments = relation.href.split("/");
-  return segments[segments.length - 1];
+  return segments[segments.length - 1] || "";
 }
 
 export function extractResourceNameFromLink(

--- a/src/types/deploy.ts
+++ b/src/types/deploy.ts
@@ -116,7 +116,9 @@ export type OperationStatus = "queued" | "running" | "failed" | "succeeded";
 
 export interface DeployOperation extends Timestamps {
   id: string;
-  resourceId: number;
+  environmentId: string;
+  codeScanResultId: string;
+  resourceId: string;
   resourceType: string;
   type: string;
   status: OperationStatus;
@@ -146,6 +148,7 @@ export interface DeployOperationResponse {
   updated_at: string;
   _links: {
     resource: LinkResponse;
+    code_scan_result: LinkResponse;
   };
 }
 

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -12,6 +12,7 @@ import type {
   DeployLogDrain,
   DeployService,
   DeployStack,
+  DeployOperation,
 } from "./deploy";
 import type { ModalState } from "./modal";
 
@@ -82,6 +83,7 @@ export interface DeployState {
   databaseImages: MapEntity<DeployDatabaseImage>;
   services: MapEntity<DeployService>;
   logDrains: MapEntity<DeployLogDrain>;
+  operations: MapEntity<DeployOperation>;
 }
 
 export interface AppState extends QueryState {

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { useApi, useCache, useLoaderSuccess, useQuery } from "saga-query/react";
 import { selectLoaderById } from "saga-query";
 
+import { prettyDateTime } from "@app/date";
 import {
   createProjectAddKeyUrl,
   createProjectAddNameUrl,
@@ -17,7 +18,7 @@ import { selectCurrentUser } from "@app/users";
 import {
   AppState,
   DeployDatabaseImage,
-  DeployOperationResponse,
+  DeployOperation,
   HalEmbedded,
 } from "@app/types";
 
@@ -36,9 +37,12 @@ import {
 import { AddSSHKeyForm } from "../shared/add-ssh-key";
 import { createProject, deployProject, TextVal } from "@app/projects";
 import {
+  cancelAppOpsPoll,
   fetchAllStacks,
   fetchApp,
+  fetchAppOperations,
   fetchEnvironment,
+  pollAppOperations,
   selectAppById,
   selectEnvironmentById,
   selectStackPublicDefault,
@@ -46,12 +50,20 @@ import {
 import {
   cancelEnvOperationsPoll,
   pollEnvOperations,
+  selectLatestDeployOp,
+  selectLatestScanOp,
+  selectLatestSucceessScanOp,
+  selectOperationsByEnvId,
 } from "@app/deploy/operation";
 import { selectOrganizationSelected } from "@app/organizations";
 import {
   fetchAllDatabaseImages,
   selectDatabaseImagesAsList,
 } from "@app/deploy/database-images";
+import {
+  DeployCodeScanResponse,
+  fetchCodeScanResult,
+} from "@app/deploy/code-scan-result";
 
 export const CreateProjectLayout = () => {
   return (
@@ -70,10 +82,6 @@ export const CreateProjectGitPage = () => {
   const query = useCache<HalEmbedded<{ ssh_keys: any[] }>>(
     fetchSSHKeys({ userId: user.id }),
   );
-
-  useEffect(() => {
-    query.trigger();
-  }, [user.id]);
 
   if (query.isInitialLoading) return <Loading />;
   if (query.isError) return <ErrorResources message={query.message} />;
@@ -192,53 +200,63 @@ export const CreateProjectNamePage = () => {
   );
 };
 
-const OpResult = ({ op }: { op: DeployOperationResponse }) => {
+const OpResult = ({ op }: { op: DeployOperation }) => {
   const postfix = `operation: ${op.id}`;
   if (op.status === "failed") {
     return (
-      <Banner variant="error">Scanning operation failed, {postfix}</Banner>
+      <Banner variant="error">
+        {op.type} operation failed, {postfix}
+      </Banner>
     );
   }
   if (op.status === "succeeded") {
-    return <Banner variant="success">Scan success, {postfix}</Banner>;
+    return (
+      <Banner variant="success">
+        {op.type} success, {postfix}
+      </Banner>
+    );
   }
   if (op.status === "running") {
     return (
-      <Banner variant="info">Git push detected (running), {postfix}</Banner>
+      <Banner variant="info">
+        {op.type} detected (running), {postfix}
+      </Banner>
     );
   }
-  return <Banner variant="info">Git push detected (queued), {postfix}</Banner>;
+  return (
+    <Banner variant="info">
+      {op.type} detected (queued), {postfix}
+    </Banner>
+  );
 };
 
 export const CreateProjectGitPushPage = () => {
-  const { appId = "" } = useParams();
+  const dispatch = useDispatch();
   const navigate = useNavigate();
+  const { appId = "" } = useParams();
+
   useQuery(fetchApp({ id: appId }));
   const app = useSelector((s: AppState) => selectAppById(s, { id: appId }));
+  useQuery(pollAppOperations({ id: appId }));
+  const scanOp = useSelector((s: AppState) => selectLatestScanOp(s, { appId }));
+  const deployOp = useSelector((s: AppState) =>
+    selectLatestDeployOp(s, { appId }),
+  );
+
   const envId = app.environmentId;
+  useQuery(fetchEnvironment({ id: envId }));
   const env = useSelector((s: AppState) =>
     selectEnvironmentById(s, { id: envId }),
   );
-  useQuery(fetchEnvironment({ id: env.id }));
-  const dispatch = useDispatch();
-  const cancel = () => dispatch(cancelEnvOperationsPoll());
-  const ops = useCache<HalEmbedded<{ operations: DeployOperationResponse[] }>>(
-    pollEnvOperations({ envId }),
-  );
-  let scanOp: DeployOperationResponse | undefined;
-
-  scanOp = ops.data
-    ? ops.data._embedded.operations.find((op) => op.type === "deploy")
-    : undefined;
 
   useEffect(() => {
+    const cancel = () => dispatch(cancelAppOpsPoll());
     cancel();
-    dispatch(pollEnvOperations({ envId }));
-
+    dispatch(pollAppOperations({ id: appId }));
     return () => {
       cancel();
     };
-  }, [appId, envId]);
+  }, [appId]);
 
   useEffect(() => {
     if (scanOp && scanOp.status === "succeeded") {
@@ -269,7 +287,16 @@ export const CreateProjectGitPushPage = () => {
           <h2 className={tokens.type.h3}>Push your code</h2>
           <PreCode>git push aptible main</PreCode>
         </div>
+
         <hr className="my-4" />
+
+        {deployOp ? (
+          <div>
+            We detected an app deployment, did you push to the{" "}
+            <code>aptible-scan</code> branch?
+          </div>
+        ) : null}
+
         {scanOp ? (
           <OpResult op={scanOp} />
         ) : (
@@ -354,14 +381,31 @@ const validateEnvs = (items: TextVal[]): ValidatorError[] => {
   return errors;
 };
 
+const useLatestCodeResults = (appId: string) => {
+  const appOps = useQuery(fetchAppOperations({ id: appId }));
+  const scanOp = useSelector((s: AppState) =>
+    selectLatestSucceessScanOp(s, { appId }),
+  );
+
+  const codeScan = useCache<DeployCodeScanResponse>(
+    fetchCodeScanResult({ id: scanOp.codeScanResultId }),
+  );
+
+  return { scanOp, codeScan, appOps };
+};
+
 export const CreateProjectGitSettingsPage = () => {
-  const { appId = "" } = useParams();
-  useQuery(fetchApp({ id: appId }));
-  const app = useSelector((s: AppState) => selectAppById(s, { id: appId }));
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const { appId = "" } = useParams();
+
+  useQuery(fetchApp({ id: appId }));
+  const app = useSelector((s: AppState) => selectAppById(s, { id: appId }));
+  const { scanOp, codeScan, appOps } = useLatestCodeResults(appId);
+
   const query = useQuery(fetchAllDatabaseImages());
   const dbImages = useSelector(selectDatabaseImagesAsList);
+
   const [dbs, setDbs] = useState("postgresql=14");
   const [dbErrors, setDbErrors] = useState<ValidatorError[]>([]);
   const [envs, setEnvs] = useState(["STRIPE_SECRET_KEY=1234"].join("\n"));
@@ -374,7 +418,6 @@ export const CreateProjectGitSettingsPage = () => {
   const loader = useSelector((s: AppState) =>
     selectLoaderById(s, { id: `${deployProject}` }),
   );
-  console.log(`${deployProject}`, loader);
   const onSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     let cancel = false;
@@ -421,10 +464,6 @@ export const CreateProjectGitSettingsPage = () => {
     );
   };
 
-  useEffect(() => {
-    query.trigger();
-  }, []);
-
   useLoaderSuccess(loader, () => {
     navigate(createProjectGitStatusUrl(appId));
   });
@@ -442,6 +481,45 @@ export const CreateProjectGitSettingsPage = () => {
         prev={createProjectGitPushUrl(appId)}
         next={createProjectGitStatusUrl(appId)}
       />
+
+      <Box>
+        {codeScan.isInitialLoading ? (
+          "Loading code scan results ...."
+        ) : (
+          <div>
+            <div className="flex items-center justify-between">
+              <h3 className={tokens.type.h3}>Code scan results</h3>
+              <Button
+                variant="white"
+                isLoading={appOps.isLoading}
+                onClick={() => appOps.trigger()}
+              >
+                Refresh
+              </Button>
+            </div>
+
+            <dl className="mt-2">
+              <dd>Last scan</dd>
+              <dt>{prettyDateTime(scanOp.updatedAt)}</dt>
+
+              <dd>
+                <code>Dockerfile</code> detected?
+              </dd>
+              <dt>{codeScan.data?.dockerfile_present ? "Yes" : "No"}</dt>
+
+              <dd>
+                <code>Procfile</code> detected?
+              </dd>
+              <dt>{codeScan.data?.procfile_present ? "Yes" : "No"}</dt>
+
+              <dd>
+                <code>aptible.yml</code> detected?
+              </dd>
+              <dt>{codeScan.data?.aptible_yml_present ? "Yes" : "No"}</dt>
+            </dl>
+          </div>
+        )}
+      </Box>
 
       <Box>
         <form onSubmit={onSubmit}>
@@ -466,7 +544,7 @@ export const CreateProjectGitSettingsPage = () => {
             {query.isInitialLoading ? (
               <Loading text="Loading databases" />
             ) : (
-              <ul>
+              <ul className="inline-grid grid-cols-3">
                 {dbImages.map((d) => {
                   return (
                     <li key={d.id}>
@@ -540,21 +618,11 @@ export const CreateProjectGitSettingsPage = () => {
   );
 };
 
-const Op = ({ op }: { op: DeployOperationResponse }) => {
-  const resource = op._links.resource?.href.split("/") || ["", "", ""];
+const Op = ({ op }: { op: DeployOperation }) => {
+  const resource = op.resourceType;
   return (
-    <div>
-      {resource[resource.length - 2]}:{op.type} - {op.status}
-    </div>
-  );
-};
-
-const Ops = ({ ops = [] }: { ops?: DeployOperationResponse[] }) => {
-  return (
-    <div>
-      {ops.map((op) => {
-        return <Op key={op.id} op={op} />;
-      })}
+    <div className="border-b-2 py-4">
+      {resource}:{op.type} - {op.status}
     </div>
   );
 };
@@ -565,14 +633,11 @@ export const CreateProjectGitStatusPage = () => {
   useQuery(fetchApp({ id: appId }));
   const app = useSelector((s: AppState) => selectAppById(s, { id: appId }));
   const envId = app.environmentId;
-  const env = useSelector((s: AppState) =>
-    selectEnvironmentById(s, { id: envId }),
+  useQuery(fetchEnvironment({ id: envId }));
+  const { isInitialLoading } = useQuery(pollEnvOperations({ envId }));
+  const ops = useSelector((s: AppState) =>
+    selectOperationsByEnvId(s, { envId }),
   );
-  useQuery(fetchEnvironment({ id: env.id }));
-  const ops = useCache<HalEmbedded<{ operations: DeployOperationResponse[] }>>(
-    pollEnvOperations({ envId }),
-  );
-  useEffect(() => {}, []);
 
   const cancel = () => dispatch(cancelEnvOperationsPoll());
   useEffect(() => {
@@ -593,10 +658,19 @@ export const CreateProjectGitStatusPage = () => {
 
       <FormNav prev={createProjectGitSettingsUrl(appId)} />
       <Box>
-        {ops.isInitialLoading ? (
+        <div className="border-b-2 py-4">
+          <h2 className={tokens.type.h2}>{app.handle}</h2>
+          <p>Text for URL</p>
+        </div>
+
+        {isInitialLoading ? (
           <Loading text="Provisioning resources ..." />
         ) : (
-          <Ops ops={ops.data?._embedded.operations} />
+          <div>
+            {ops.map((op) => {
+              return <Op key={op.id} op={op} />;
+            })}
+          </div>
         )}
       </Box>
     </div>

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -484,7 +484,7 @@ export const CreateProjectGitSettingsPage = () => {
 
       <Box>
         {codeScan.isInitialLoading ? (
-          "Loading code scan results ...."
+          <Loading text="Loading code scan results ..." />
         ) : (
           <div>
             <div className="flex items-center justify-between">

--- a/yarn.lock
+++ b/yarn.lock
@@ -2775,10 +2775,10 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-saga-query@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/saga-query/-/saga-query-5.1.0.tgz#2b32ab9551de120e41804c59fa653988ae14db42"
-  integrity sha512-lmlqmDxzXNgWZ9xb2DZO+Ck+OTkqQuGoebB4vwYl5MZMWTVKEJq6bTk35QHfJlnQdxeZ+rzP8GOtZTODmdd+tQ==
+saga-query@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/saga-query/-/saga-query-6.1.0.tgz#b0b9d3ca38632afa4bc901a0a0cc90ff833c873a"
+  integrity sha512-CWTDSYZ8oRYa4SGci+NcFt5QuMpPBr6Ixjon0x8hVTawFSstS3IYPRA+652D6qaUymPBaL5mxajZ+rZ+ESxIlQ==
   dependencies:
     redux "^4.1.2"
     redux-batched-actions "^0.5.0"


### PR DESCRIPTION
This commit also:

- Displays results of code scan on the create git settings page
- Save all operations inside redux as its own separate entity (as opposed to using auto-caching)
    - And create selectors to pull data from that redux slice
- Created a discriminated union for the `createAppOperation` endpoint
- Adds `app:deploy` as an operation for `createAppOperation`
- Uses `app:deploy` inside `deployProject`

