### PR TITLE
chore(ftux): use saga-query fetchRetry middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "redux-batched-actions": "^0.5.0",
     "redux-persist": "^6.0.0",
     "rome": "^11.0.0",
-    "saga-query": "^7.1.0",
+    "saga-query": "^7.2.0",
     "tailwindcss": "^3.2.4",
     "typescript": "^4.9.4",
     "vite": "^4.0.4",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -13,8 +13,6 @@ import {
   setLoaderError,
   all,
   setLoaderSuccess,
-  delay,
-  createKey,
 } from "saga-query";
 import type {
   ApiCtx,
@@ -214,44 +212,6 @@ export function combinePages<
 
 export interface Retryable {
   attempts?: number;
-}
-
-/**
- * This middleware will retry calling the endpoint when there is a failure until
- * `maxAttempts` is reached.
- */
-export function retryable(
-  {
-    waitTime = 1000,
-    maxAttempts = 5,
-  }: {
-    waitTime: number;
-    maxAttempts: number;
-  } = { waitTime: 1000, maxAttempts: 3 },
-) {
-  return function* (ctx: ApiCtx<Retryable>, next: Next) {
-    const { attempts = 0, ...payload } = ctx.payload;
-    // we need to overwrite the key here because the endpoint is retryable
-    // and we don't want the retry property to change the key which is how we cache
-    // the data.
-    // https://github.com/redux-saga/saga-query/blob/04765799123412385404d07c949cac26eb67378b/src/middleware.ts#L266
-    ctx.key = createKey(ctx.name, payload);
-
-    yield next();
-
-    // if request is successful, no need to retry
-    if (ctx.json.ok) {
-      return;
-    }
-
-    if (attempts >= maxAttempts) {
-      return;
-    }
-
-    yield delay(waitTime);
-    const fn = ctx.actionFn;
-    yield put(fn({ ...ctx.payload, attempts: attempts + 1 }));
-  };
 }
 
 export const thunks = createPipe<ThunkCtx>();

--- a/src/deploy/operation/index.ts
+++ b/src/deploy/operation/index.ts
@@ -1,11 +1,4 @@
-import {
-  api,
-  combinePages,
-  PaginateProps,
-  thunks,
-  retryable,
-  Retryable,
-} from "@app/api";
+import { api, combinePages, PaginateProps, thunks, Retryable } from "@app/api";
 import {
   defaultEntity,
   extractIdFromLink,
@@ -24,7 +17,7 @@ import type {
   OperationType,
 } from "@app/types";
 import { createAction, createSelector } from "@reduxjs/toolkit";
-import { call, poll } from "saga-query";
+import { call, poll, fetchRetry } from "saga-query";
 import { selectDeploy } from "../slice";
 
 export interface DeployOperationResponse {
@@ -242,7 +235,6 @@ export const pollEnvOperations = thunks.create<EnvIdProps>(
 export const fetchOperationLogs = api.get<{ id: string } & Retryable, string>(
   "/operations/:id/logs",
   [
-    retryable(),
     function* (ctx, next) {
       ctx.cache = true;
       ctx.bodyType = "text";
@@ -268,6 +260,7 @@ export const fetchOperationLogs = api.get<{ id: string } & Retryable, string>(
       // so we can just fetch the data in a single endpoint
       ctx.json.data = data;
     },
+    fetchRetry(),
   ],
 );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2862,10 +2862,10 @@ safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-saga-query@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/saga-query/-/saga-query-7.1.0.tgz#9f2102bd04df59d10e04cf3f89ac25ff07605224"
-  integrity sha512-Hzbu8Dq/bFa4RhDQ74rZaVQ2MelHGg2HUCYe7DF+Mz7nnGfhUR7f8F+EevoJnElKz07dua56wrCbnDtidJ3G5A==
+saga-query@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/saga-query/-/saga-query-7.2.0.tgz#d2685a7f72cff9a875f10574a1a91bada15a0c42"
+  integrity sha512-qHuUDG4Khe+KVNgNh1mHTXs+gyp5ytm53Oju3RkWJZSFPecLDm4iyQ3dQPk3GuqztPjoTFV+ay4oY43L1T2w3Q==
   dependencies:
     redux "^4.1.2"
     redux-batched-actions "^0.5.0"


### PR DESCRIPTION
The `fetchRetry` middleware from `saga-query` accesses the actual fetch request and will keep calling it multiple times until there is a success.

You can read more here: https://github.com/redux-saga/saga-query/releases/tag/v7.2.0