### PR TITLE
chore: added redux dev tools extension optionally

### DIFF
--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,4 @@
-import { createStore, applyMiddleware } from "@reduxjs/toolkit";
+import { createStore, applyMiddleware, compose } from "@reduxjs/toolkit";
 import type { Middleware, Store } from "@reduxjs/toolkit";
 import { PersistPartial } from "redux-persist/es/persistReducer";
 import { persistStore, persistReducer } from "redux-persist";
@@ -60,11 +60,13 @@ export function setupStore({ initState }: Props): AppStore<AppState> {
   // reset the store when a user logs out
   const baseReducer = resetReducer(prepared.reducer, persistConfig);
   const persistedReducer = persistReducer(persistConfig, baseReducer);
+  const composeEnhancers =
+    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
   const store = createStore(
     persistedReducer,
     initState as AppState & PersistPartial,
-    applyMiddleware(...middleware),
+    composeEnhancers(applyMiddleware(...middleware)),
   );
   const persistor = persistStore(store);
 

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,4 +1,4 @@
-import { compose, configureStore } from "@reduxjs/toolkit";
+import { configureStore } from "@reduxjs/toolkit";
 import type { Middleware, Store } from "@reduxjs/toolkit";
 import { persistStore, persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage"; // defaults to localStorage for web

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,6 +1,5 @@
-import { createStore, applyMiddleware, compose } from "@reduxjs/toolkit";
+import { compose, configureStore } from "@reduxjs/toolkit";
 import type { Middleware, Store } from "@reduxjs/toolkit";
-import { PersistPartial } from "redux-persist/es/persistReducer";
 import { persistStore, persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage"; // defaults to localStorage for web
 import { BATCH, prepareStore } from "saga-query";
@@ -60,14 +59,13 @@ export function setupStore({ initState }: Props): AppStore<AppState> {
   // reset the store when a user logs out
   const baseReducer = resetReducer(prepared.reducer, persistConfig);
   const persistedReducer = persistReducer(persistConfig, baseReducer);
-  const composeEnhancers =
-    (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-  const store = createStore(
-    persistedReducer,
-    initState as AppState & PersistPartial,
-    composeEnhancers(applyMiddleware(...middleware)),
-  );
+  const store = configureStore({
+    preloadedState: initState,
+    reducer: persistedReducer,
+    devTools: process.env.NODE_ENV !== "production",
+    middleware: middleware,
+  });
   const persistor = persistStore(store);
 
   prepared.run();


### PR DESCRIPTION
Leaving as draft. This should have no impact (or nearly no impact). There are all sorts of blog posts and stuff about customizing this thing for prod: https://medium.com/@zalmoxis/using-redux-devtools-in-production-4c5b56c5600f, but I think we can really just use this and there's some primitive settings we can use to disable in prod if you wish.

Similarly we're using a deprecated method, which I'm trying to solve here:

<img width="441" alt="image" src="https://user-images.githubusercontent.com/2961973/222033805-08195ea3-4b97-45ec-bf80-d16b5559a336.png">


---

Proof:

<img width="1263" alt="image" src="https://user-images.githubusercontent.com/2961973/222033515-03cf83cd-0131-4451-ba13-f7e723a33f5f.png">


Pretty handy dandy to view state:

<img width="1293" alt="image" src="https://user-images.githubusercontent.com/2961973/222033591-2618c6e5-1210-409c-a088-af1d681e4e83.png">
