### PR TITLE
feat: added settings/deprovision page for apps

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -69,12 +69,12 @@ const appRoutes: RouteObject[] = [
             index: true,
             element: <AppsPage />,
           },
+
           {
-            path: routes.APP_DETAIL_PATH,
             element: <AppDetailLayout />,
             children: [
               {
-                index: true,
+                path: routes.APP_OVERVIEW_PATH,
                 element: <AppDetailPage />,
               },
               {

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -103,11 +103,10 @@ const appRoutes: RouteObject[] = [
           },
 
           {
-            path: routes.DATABASE_DETAIL_PATH,
             element: <DatabaseDetailLayout />,
             children: [
               {
-                index: true,
+                path: routes.DATABASE_OVERVIEW_PATH,
                 element: <DatabaseDetailPage />,
               },
               {

--- a/src/deploy/app/index.ts
+++ b/src/deploy/app/index.ts
@@ -226,35 +226,48 @@ interface ConfigAppOpProps {
   env: { [key: string]: string };
 }
 
-type CreateAppOpProps = ScanAppOpProps | DeployAppOpProps | ConfigAppOpProps;
-export const createAppOperation = api.post<
-  CreateAppOpProps,
-  DeployOperationResponse
->("/apps/:appId/operations", function* (ctx, next) {
-  const { type } = ctx.payload;
+interface DeprovisionAppOpProps {
+  type: "deprovision";
+  appId: string;
+}
 
-  const getBody = () => {
-    switch (type) {
-      case "deploy":
-      case "scan_code": {
-        const { gitRef } = ctx.payload;
-        return { type, git_ref: gitRef };
+type AppOpProps =
+  | ScanAppOpProps
+  | DeployAppOpProps
+  | DeprovisionAppOpProps
+  | ConfigAppOpProps;
+export const createAppOperation = api.post<AppOpProps, DeployOperationResponse>(
+  "/apps/:appId/operations",
+  function* (ctx, next) {
+    const { type } = ctx.payload;
+
+    const getBody = () => {
+      switch (type) {
+        case "deprovision": {
+          return { type };
+        }
+
+        case "deploy":
+        case "scan_code": {
+          const { gitRef } = ctx.payload;
+          return { type, git_ref: gitRef };
+        }
+
+        case "configure": {
+          const { env } = ctx.payload;
+          return { type, env };
+        }
+
+        default:
+          return {};
       }
+    };
 
-      case "configure": {
-        const { env } = ctx.payload;
-        return { type, env };
-      }
-
-      default:
-        return {};
-    }
-  };
-
-  const body = getBody();
-  ctx.request = ctx.req({ body: JSON.stringify(body) });
-  yield next();
-});
+    const body = getBody();
+    ctx.request = ctx.req({ body: JSON.stringify(body) });
+    yield next();
+  },
+);
 
 export const appEntities = {
   app: defaultEntity({

--- a/src/deploy/database/index.ts
+++ b/src/deploy/database/index.ts
@@ -3,6 +3,7 @@ import {
   FetchJson,
   Payload,
   put,
+  select,
   setLoaderError,
   setLoaderStart,
   setLoaderSuccess,
@@ -33,7 +34,7 @@ import {
   mustSelectEntity,
 } from "@app/slice-helpers";
 
-import { deserializeDeployOperation } from "../operation";
+import { deserializeDeployOperation, waitForOperation } from "../operation";
 import { deserializeDisk } from "../disk";
 import { selectDeploy } from "../slice";
 import { createSelector } from "@reduxjs/toolkit";
@@ -357,3 +358,21 @@ export const databaseEntities = {
     save: addDeployDatabases,
   }),
 };
+
+export const deprovisionDatabase = thunks.create<{
+  dbId: string;
+}>("deprovision-database", function* (ctx, next) {
+  const { dbId } = ctx.payload;
+  yield* select(selectDatabaseById, { id: dbId });
+
+  const deprovisionCtx = yield* call(
+    createDatabaseOperation.run,
+    createDatabaseOperation({
+      type: "deprovision",
+      dbId,
+    }),
+  );
+
+  if (!deprovisionCtx.json.ok) return;
+  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
+});

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -13,6 +13,7 @@ import { createLog } from "@app/debug";
 import { ThunkCtx, thunks } from "@app/api";
 import {
   createAppOperation,
+  createDatabaseOperation,
   createDeployApp,
   createDeployEnvironment,
   fetchDatabase,
@@ -21,6 +22,7 @@ import {
   hasDeployEnvironment,
   provisionDatabase,
   selectAppById,
+  selectDatabaseById,
   selectEnvironmentByName,
 } from "@app/deploy";
 import { createServiceDefinition } from "@app/deploy/app-service-definitions";
@@ -363,6 +365,24 @@ export const deprovisionApp = thunks.create<{
     createAppOperation({
       type: "deprovision",
       appId,
+    }),
+  );
+
+  if (!deprovisionCtx.json.ok) return;
+  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
+});
+
+export const deprovisionDatabase = thunks.create<{
+  dbId: string;
+}>("deprovision-database", function* (ctx, next) {
+  const { dbId } = ctx.payload;
+  yield* select(selectDatabaseById, { id: dbId });
+
+  const deprovisionCtx = yield* call(
+    createDatabaseOperation.run,
+    createDatabaseOperation({
+      type: "deprovision",
+      dbId,
     }),
   );
 

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -351,3 +351,21 @@ export const updateEnvWithDbUrls = thunks.create<{
 
   yield next();
 });
+
+export const deprovisionApp = thunks.create<{
+  appId: string;
+}>("deprovision-app", function* (ctx, next) {
+  const { appId } = ctx.payload;
+  yield* select(selectAppById, { id: appId });
+
+  const deprovisionCtx = yield* call(
+    createAppOperation.run,
+    createAppOperation({
+      type: "deprovision",
+      appId,
+    }),
+  );
+
+  if (!deprovisionCtx.json.ok) return;
+  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
+});

--- a/src/projects/index.ts
+++ b/src/projects/index.ts
@@ -353,39 +353,3 @@ export const updateEnvWithDbUrls = thunks.create<{
 
   yield next();
 });
-
-export const deprovisionApp = thunks.create<{
-  appId: string;
-}>("deprovision-app", function* (ctx, next) {
-  const { appId } = ctx.payload;
-  yield* select(selectAppById, { id: appId });
-
-  const deprovisionCtx = yield* call(
-    createAppOperation.run,
-    createAppOperation({
-      type: "deprovision",
-      appId,
-    }),
-  );
-
-  if (!deprovisionCtx.json.ok) return;
-  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
-});
-
-export const deprovisionDatabase = thunks.create<{
-  dbId: string;
-}>("deprovision-database", function* (ctx, next) {
-  const { dbId } = ctx.payload;
-  yield* select(selectDatabaseById, { id: dbId });
-
-  const deprovisionCtx = yield* call(
-    createDatabaseOperation.run,
-    createDatabaseOperation({
-      type: "deprovision",
-      dbId,
-    }),
-  );
-
-  if (!deprovisionCtx.json.ok) return;
-  yield* call(waitForOperation, { id: `${deprovisionCtx.json.data.id}` });
-});

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -53,6 +53,8 @@ export const APPS_PATH = "/apps";
 export const appsUrl = () => APPS_PATH;
 export const APP_DETAIL_PATH = "/apps/:id";
 export const appDetailUrl = (id: string) => `/apps/${id}`;
+export const APP_OVERVIEW_PATH = `${APP_DETAIL_PATH}/overview`;
+export const appOverviewUrl = (id: string) => `${appDetailUrl(id)}/overview`;
 export const APP_ACTIVITY_PATH = `${APP_DETAIL_PATH}/activity`;
 export const appActivityUrl = (id: string) => `${appDetailUrl(id)}/activity`;
 export const APP_SECURITY_PATH = `${APP_DETAIL_PATH}/security`;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -63,9 +63,12 @@ export const APP_SETTINGS_PATH = `${APP_DETAIL_PATH}/settings`;
 export const appSettingsUrl = (id: string) => `${appDetailUrl(id)}/settings`;
 
 export const DATABASES_PATH = "/databases";
-export const databasesUrl = () => DATABASES_PATH;
+export const databaseUrl = () => DATABASES_PATH;
 export const DATABASE_DETAIL_PATH = "/databases/:id";
 export const databaseDetailUrl = (id: string) => `/databases/${id}`;
+export const DATABASE_OVERVIEW_PATH = `${DATABASE_DETAIL_PATH}/overview`;
+export const databaseOverviewUrl = (id: string) =>
+  `${databaseDetailUrl(id)}/overview`;
 export const DATABASE_ACTIVITY_PATH = `${DATABASE_DETAIL_PATH}/activity`;
 export const databaseActivityUrl = (id: string) =>
   `${databaseDetailUrl(id)}/activity`;

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -6,7 +6,7 @@ import type { AppState, DeployApp } from "@app/types";
 import { selectAppById } from "@app/deploy";
 import {
   appActivityUrl,
-  appDetailUrl,
+  appOverviewUrl,
   appSecurityUrl,
   appSettingsUrl,
   appsUrl,
@@ -80,7 +80,7 @@ function AppPageHeader() {
   const app = useSelector((s: AppState) => selectAppById(s, { id }));
 
   const tabs = [
-    { name: "Overview", href: appDetailUrl(id) },
+    { name: "Overview", href: appOverviewUrl(id) },
     { name: "Activity", href: appActivityUrl(id) },
     { name: "Security", href: appSecurityUrl(id) },
     { name: "Settings", href: appSettingsUrl(id) },

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -3,13 +3,14 @@ import { useSelector } from "react-redux";
 
 import { prettyEnglishDate } from "@app/date";
 import type { AppState, DeployApp } from "@app/types";
-import { selectAppById } from "@app/deploy";
+import { selectAppById, selectEnvironmentById } from "@app/deploy";
 import {
   appActivityUrl,
   appOverviewUrl,
   appSecurityUrl,
   appSettingsUrl,
   appsUrl,
+  environmentResourcelUrl,
 } from "@app/routes";
 
 import {
@@ -18,6 +19,7 @@ import {
   DetailPageHeaderView,
   IconCopy,
   IconExternalLink,
+  IconGitBranch,
   TabItem,
   tokens,
 } from "../shared";
@@ -25,44 +27,56 @@ import {
 import { DetailPageLayout } from "./detail-page";
 import { capitalize } from "@app/string-utils";
 
-const crumbs = [{ name: "Apps", to: appsUrl() }];
-
 const appDetailBox = ({ app }: { app: DeployApp }): React.ReactElement => (
-  <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 w-full py-6">
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 w-full py-6 -mt-5 -mb-5">
     <Box>
       <Button className="flex ml-auto" variant="white">
         View Docs
         <IconExternalLink className="inline ml-3 h-5 mt-0" />
       </Button>
-      <h1 className="text-lg text-gray-500 -mt-10">App Details</h1>
+      <h1 className="text-md text-gray-500 -mt-10">App Details</h1>
       <div className="flex w-1/1">
         <div className="flex-col w-1/2">
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Git Remote</h3>
+            <h3 className="text-base font-semibold text-gray-900">
+              Git Remote
+            </h3>
             <p>
               {app.gitRepo} <IconCopy className="inline h-4" color="#888C90" />
             </p>
           </div>
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Git Ref</h3>
+            <h3 className="text-base font-semibold text-gray-900">Git Ref</h3>
             <p>Unused</p>
           </div>
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Docker Image</h3>
+            <h3 className="text-base font-semibold text-gray-900">
+              Docker Image
+            </h3>
             {app.currentImage?.dockerRepo}
           </div>
         </div>
         <div className="flex-col w-1/2">
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Repository</h3>
+            <h3 className="text-base font-semibold text-gray-900">
+              Repository
+            </h3>
             <p>{app.handle}</p>
           </div>
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Branch</h3>
-            <p>main</p>
+            <h3 className="text-base font-semibold text-gray-900">Branch</h3>
+            <p>
+              <IconGitBranch
+                className="inline"
+                style={{ width: 16, height: 16 }}
+              />{" "}
+              main
+            </p>
           </div>
           <div className="mt-4">
-            <h3 className={tokens.type.h4}>Last Deployed</h3>
+            <h3 className="text-base font-semibold text-gray-900">
+              Last Deployed
+            </h3>
             {app.lastDeployOperation
               ? `${capitalize(
                   app.lastDeployOperation.type,
@@ -78,6 +92,12 @@ const appDetailBox = ({ app }: { app: DeployApp }): React.ReactElement => (
 function AppPageHeader() {
   const { id = "" } = useParams();
   const app = useSelector((s: AppState) => selectAppById(s, { id }));
+  const environment = useSelector((s: AppState) =>
+    selectEnvironmentById(s, { id: app.environmentId }),
+  );
+  const crumbs = [
+    { name: environment.handle, to: environmentResourcelUrl(environment.id) },
+  ];
 
   const tabs = [
     { name: "Overview", href: appOverviewUrl(id) },

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -98,6 +98,9 @@ function AppPageHeader() {
   const crumbs = [
     { name: environment.handle, to: environmentResourcelUrl(environment.id) },
   ];
+  // TODO - COME BACK TO THIS
+  // Need to kick a user back out of the details page (or lock specific pages if it is deleted)
+  // currently the network log will error with a 404 (as the record will be deleted)
 
   const tabs = [
     { name: "Overview", href: appOverviewUrl(id) },

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -9,7 +9,6 @@ import {
   appOverviewUrl,
   appSecurityUrl,
   appSettingsUrl,
-  appsUrl,
   environmentResourcelUrl,
 } from "@app/routes";
 

--- a/src/ui/layouts/app-detail-layout.tsx
+++ b/src/ui/layouts/app-detail-layout.tsx
@@ -1,7 +1,8 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 
-import type { AppState } from "@app/types";
+import { prettyEnglishDate } from "@app/date";
+import type { AppState, DeployApp } from "@app/types";
 import { selectAppById } from "@app/deploy";
 import {
   appActivityUrl,
@@ -11,11 +12,68 @@ import {
   appsUrl,
 } from "@app/routes";
 
-import { DetailPageHeaderView, TabItem } from "../shared";
+import {
+  Box,
+  Button,
+  DetailPageHeaderView,
+  IconCopy,
+  IconExternalLink,
+  TabItem,
+  tokens,
+} from "../shared";
 
 import { DetailPageLayout } from "./detail-page";
+import { capitalize } from "@app/string-utils";
 
 const crumbs = [{ name: "Apps", to: appsUrl() }];
+
+const appDetailBox = ({ app }: { app: DeployApp }): React.ReactElement => (
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 w-full py-6">
+    <Box>
+      <Button className="flex ml-auto" variant="white">
+        View Docs
+        <IconExternalLink className="inline ml-3 h-5 mt-0" />
+      </Button>
+      <h1 className="text-lg text-gray-500 -mt-10">App Details</h1>
+      <div className="flex w-1/1">
+        <div className="flex-col w-1/2">
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Git Remote</h3>
+            <p>
+              {app.gitRepo} <IconCopy className="inline h-4" color="#888C90" />
+            </p>
+          </div>
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Git Ref</h3>
+            <p>Unused</p>
+          </div>
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Docker Image</h3>
+            {app.currentImage?.dockerRepo}
+          </div>
+        </div>
+        <div className="flex-col w-1/2">
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Repository</h3>
+            <p>{app.handle}</p>
+          </div>
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Branch</h3>
+            <p>main</p>
+          </div>
+          <div className="mt-4">
+            <h3 className={tokens.type.h4}>Last Deployed</h3>
+            {app.lastDeployOperation
+              ? `${capitalize(
+                  app.lastDeployOperation.type,
+                )} on ${prettyEnglishDate(app.lastDeployOperation?.createdAt)}`
+              : "Unknown"}
+          </div>
+        </div>
+      </div>
+    </Box>
+  </div>
+);
 
 function AppPageHeader() {
   const { id = "" } = useParams();
@@ -29,11 +87,14 @@ function AppPageHeader() {
   ] as TabItem[];
 
   return (
-    <DetailPageHeaderView
-      breadcrumbs={crumbs}
-      title={app ? app.handle : "Loading..."}
-      tabs={tabs}
-    />
+    <>
+      <DetailPageHeaderView
+        breadcrumbs={crumbs}
+        title={app ? app.handle : "Loading..."}
+        detailsBox={appDetailBox({ app })}
+        tabs={tabs}
+      />
+    </>
   );
 }
 

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -1,7 +1,7 @@
 import { Outlet, useParams } from "react-router-dom";
 import { useSelector } from "react-redux";
 
-import type { AppState } from "@app/types";
+import type { AppState, DeployDatabase } from "@app/types";
 import { selectDatabaseById } from "@app/deploy";
 import {
   databaseActivityUrl,
@@ -12,11 +12,107 @@ import {
   databaseUrl,
 } from "@app/routes";
 
-import { DetailPageHeaderView, TabItem } from "../shared";
+import {
+  Box,
+  Button,
+  DetailPageHeaderView,
+  IconExternalLink,
+  TabItem,
+} from "../shared";
 
 import { DetailPageLayout } from "./detail-page";
+import { prettyEnglishDate } from "@app/date";
 
 const crumbs = [{ name: "Databases", to: databaseUrl() }];
+
+const databaseDetailBox = ({
+  database,
+}: { database: DeployDatabase }): React.ReactElement => (
+  <div className="max-w-7xl mx-auto px-4 sm:px-6 md:px-8 w-full py-6 -mt-5 -mb-5">
+    <Box>
+      <Button className="flex ml-auto" variant="white">
+        View Docs
+        <IconExternalLink className="inline ml-3 h-5 mt-0" />
+      </Button>
+      <h1 className="text-md text-gray-500 -mt-10">Database Details</h1>
+      <div className="flex w-1/1">
+        <div className="flex-col w-1/3">
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">Type</h3>
+            <p>{database.type}</p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">Disk Size</h3>
+            <p>{database.disk?.size || 0} GB</p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">
+              Container Size
+            </h3>
+            <p>
+              {
+                // TODO - need to update container on API side (memory)
+              }
+              N/A
+            </p>
+          </div>
+        </div>
+        <div className="flex-col w-1/3">
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">Disk IOPS</h3>
+            <p>{database.disk?.provisionedIops}</p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">Disk Type</h3>
+            <p>{database.disk?.ebsVolumeType}</p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">
+              Disk Encryption
+            </h3>
+            <p>
+              {
+                // TODO - what is the source of this data?
+              }
+              AES-256
+            </p>
+          </div>
+        </div>
+        <div className="flex-col w-1/3">
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">
+              Memory Limit
+            </h3>
+            <p>
+              {
+                // TODO - what is the source of this data?
+              }
+              0.5 GB
+            </p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">CPU Share</h3>
+            <p>
+              {
+                // TODO - what is the source of this data?
+              }
+              0.125
+            </p>
+          </div>
+          <div className="mt-4">
+            <h3 className="text-base font-semibold text-gray-900">Profile</h3>
+            <p>
+              {
+                // TODO - what is the source of this data?
+              }
+              General Purpose (M)
+            </p>
+          </div>
+        </div>
+      </div>
+    </Box>
+  </div>
+);
 
 function DatabasePageHeader() {
   const { id = "" } = useParams();
@@ -34,6 +130,7 @@ function DatabasePageHeader() {
     <DetailPageHeaderView
       breadcrumbs={crumbs}
       title={database ? database.handle : "Loading..."}
+      detailsBox={databaseDetailBox({ database })}
       tabs={tabs}
     />
   );

--- a/src/ui/layouts/database-detail-layout.tsx
+++ b/src/ui/layouts/database-detail-layout.tsx
@@ -3,24 +3,31 @@ import { useSelector } from "react-redux";
 
 import type { AppState } from "@app/types";
 import { selectDatabaseById } from "@app/deploy";
-import { databasesUrl } from "@app/routes";
+import {
+  databaseActivityUrl,
+  databaseBackupsUrl,
+  databaseOverviewUrl,
+  databaseSecurityUrl,
+  databaseSettingsUrl,
+  databaseUrl,
+} from "@app/routes";
 
 import { DetailPageHeaderView, TabItem } from "../shared";
 
 import { DetailPageLayout } from "./detail-page";
 
-const crumbs = [{ name: "Databases", to: databasesUrl() }];
+const crumbs = [{ name: "Databases", to: databaseUrl() }];
 
 function DatabasePageHeader() {
   const { id = "" } = useParams();
   const database = useSelector((s: AppState) => selectDatabaseById(s, { id }));
 
   const tabs = [
-    { name: "Overview", href: `/databases/${id}/overview` },
-    { name: "Activity", href: `/databases/${id}/activity` },
-    { name: "Security", href: `/databases/${id}/security` },
-    { name: "Backups", href: `/databases/${id}/backups` },
-    { name: "Settings", href: `/databases/${id}/settings` },
+    { name: "Overview", href: databaseOverviewUrl(id) },
+    { name: "Activity", href: databaseActivityUrl(id) },
+    { name: "Security", href: databaseSecurityUrl(id) },
+    { name: "Backups", href: databaseBackupsUrl(id) },
+    { name: "Settings", href: databaseSettingsUrl(id) },
   ] as TabItem[];
 
   return (

--- a/src/ui/layouts/detail-page.tsx
+++ b/src/ui/layouts/detail-page.tsx
@@ -17,7 +17,7 @@ export function DetailPageLayout({ children, header }: Props) {
 
         <div className="md:pl-64 flex flex-col flex-1">
           {header}
-          <main className={cn(tokens.layout["main width"], "py-6")}>
+          <main className={cn(tokens.layout["main width"], "py-0")}>
             {children}
           </main>
         </div>

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -31,7 +31,7 @@ export const AppSettingsPage = () => {
 
   useEffect(() => {
     setHandle(app.handle);
-  }, [app?.id]);
+  }, [app.id]);
 
   const onSubmitForm = (e: SyntheticEvent) => {
     e.preventDefault();

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -1,5 +1,4 @@
-import { fetchApp, selectAppById } from "@app/deploy";
-import { deprovisionApp } from "@app/projects";
+import { deprovisionApp, fetchApp, selectAppById } from "@app/deploy";
 import { AppState } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -58,15 +57,15 @@ export const AppSettingsPage = () => {
         <h1 className="text-lg text-gray-500">How To Deploy Changes</h1>
         <div className="mt-4">
           <h3 className="text-base font-semibold">Clone project code</h3>
-          <PreCode allowCopy>git clone {app.gitRepo}</PreCode>
+          <PreCode allowCopy text={["git", "clone", app.gitRepo]} />
         </div>
         <div className="mt-4">
           <h3 className="text-base font-semibold">Find project code</h3>
-          <PreCode allowCopy>cd {app.handle}</PreCode>
+          <PreCode allowCopy text={["cd", app.handle]} />
         </div>
         <div className="mt-4">
           <h3 className="text-base font-semibold">Deploy code changes</h3>
-          <PreCode allowCopy>git push {app.gitRepo}</PreCode>
+          <PreCode allowCopy text={["git", "push", app.gitRepo]} />
         </div>
       </Box>
       <Box>

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -7,10 +7,12 @@ import { useQuery } from "saga-query/react";
 import {
   Box,
   Button,
+  ButtonIcon,
   FormGroup,
   IconAlertTriangle,
   IconCopy,
   IconExternalLink,
+  IconPlusCircle,
   IconTrash,
   Input,
   Label,
@@ -83,9 +85,65 @@ export const AppSettingsPage = () => {
           <p>
             {app.id} <IconCopy className="inline h-4" color="#888C90" />
           </p>
-          <Label className="my-4">Thumbnail Image</Label>
-          <br />
-          <Label className="my-4">Environment Variables</Label>
+          <div className="mt-4 flex" />
+          <FormGroup label="Thumbnail Image" htmlFor="thumbnail">
+            <div className="flex justify-between items-center">
+              <select
+                onChange={() => {}}
+                value={"test"}
+                className="mb-2"
+                placeholder="select"
+                disabled
+              >
+                <option value="test" disabled>
+                  Some Icon
+                </option>
+              </select>
+            </div>
+          </FormGroup>
+          <FormGroup
+            label="Environment Variables"
+            htmlFor="environment-variables"
+          >
+            <div className="flex">
+              <Input
+                className="flex w-1/2"
+                name="app-handle"
+                type="text"
+                value={handle}
+                onChange={(e) => setHandle(e.currentTarget.value)}
+                autoComplete="name"
+                data-testid="input-name"
+                id="input-name"
+              />
+              <Input
+                className="flex ml-4 w-1/2"
+                name="app-handle"
+                type="text"
+                value={handle}
+                onChange={(e) => setHandle(e.currentTarget.value)}
+                autoComplete="name"
+                data-testid="input-name"
+                id="input-name"
+              />
+              <ButtonIcon
+                className="flex ml-4 pr-2"
+                variant="white"
+                onClick={() => {}}
+                icon={<IconTrash color='#AD1A1A' />}
+                children={null}
+              />
+            </div>
+            <div className="flex mt-4">
+              <ButtonIcon
+                icon={<IconPlusCircle color="#FFF" />}
+                variant="secondary"
+                onClick={() => {}}
+              >
+                New
+              </ButtonIcon>
+            </div>
+          </FormGroup>
           <br />
           <hr />
           <br />

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -1,3 +1,151 @@
+import { fetchApp, selectAppById } from "@app/deploy";
+import { AppState } from "@app/types";
+import { SyntheticEvent, useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { useParams } from "react-router";
+import { useQuery } from "saga-query/react";
+import {
+  Box,
+  Button,
+  FormGroup,
+  IconAlertTriangle,
+  IconCopy,
+  IconExternalLink,
+  IconTrash,
+  Input,
+  Label,
+  PreCode,
+  tokens,
+} from "../shared";
+
 export const AppSettingsPage = () => {
-  return <div>App settings page</div>;
+  const [handle, setHandle] = useState<string>("");
+  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
+  const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
+
+  const { id = "" } = useParams();
+  useQuery(fetchApp({ id }));
+  const app = useSelector((s: AppState) => selectAppById(s, { id }));
+
+  useEffect(() => {
+    setHandle(app.handle);
+  }, [app?.id]);
+
+  const onSubmitForm = (e: SyntheticEvent) => {
+    e.preventDefault();
+  };
+
+  const deprovisionApp = (e: SyntheticEvent) => {
+    e.preventDefault();
+
+    setIsDeprovisioning(true);
+  };
+
+  const disabledDeprovisioning = isDeprovisioning || handle !== deleteConfirm;
+
+  return (
+    <div>
+      <Box>
+        <Button className="relative float-right" variant="white">
+          View Docs
+          <IconExternalLink className="inline ml-3 h-5 mt-0" />
+        </Button>
+        <h1 className="text-lg text-gray-500">How To Deploy Changes</h1>
+        <div className="mt-4">
+          <h3 className={tokens.type.h4}>Clone project code</h3>
+          <PreCode allowCopy>git clone {app.gitRepo}</PreCode>
+        </div>
+        <div className="mt-4">
+          <h3 className={tokens.type.h4}>Find project code</h3>
+          <PreCode allowCopy>cd {app.handle}</PreCode>
+        </div>
+        <div className="mt-4">
+          <h3 className={tokens.type.h4}>Deploy code changes</h3>
+          <PreCode allowCopy>git push {app.gitRepo}</PreCode>
+        </div>
+      </Box>
+      <Box>
+        <h1 className="text-lg text-gray-500">App Settings</h1>
+        <br />
+        <form onSubmit={onSubmitForm}>
+          <FormGroup label="App Name" htmlFor="input-name">
+            <Input
+              name="app-handle"
+              type="text"
+              value={handle}
+              onChange={(e) => setHandle(e.currentTarget.value)}
+              autoComplete="name"
+              data-testid="input-name"
+              id="input-name"
+            />
+          </FormGroup>
+          <Label className="my-4">App ID</Label>
+          <p>
+            {app.id} <IconCopy className="inline h-4" color="#888C90" />
+          </p>
+          <Label className="my-4">Thumbnail Image</Label>
+          <br />
+          <Label className="my-4">Environment Variables</Label>
+          <br />
+          <hr />
+          <br />
+          <div className="flex">
+            <Button className="w-40 mb-4 flex" onClick={() => {}}>
+              Save Changes
+            </Button>
+            <Button
+              className="w-40 ml-4 mb-4 flex"
+              onClick={() => {}}
+              variant="white"
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </Box>
+      <Box>
+        <h1 className="text-lg text-red-500">
+          <IconAlertTriangle
+            className="inline pr-3 mb-1"
+            style={{ width: 32 }}
+            color="#AD1A1A"
+          />
+          Deprovision App
+        </h1>
+        <div className="mt-2">
+          <p>
+            This will permanently deprovision <strong>{app.handle}</strong> app.
+            This action cannot be undone. If you want to proceed, type Delete
+            below to continue.
+          </p>
+          <div className="flex mt-4 wd-60">
+            <Input
+              className="flex"
+              disabled={isDeprovisioning}
+              name="delete-confirm"
+              type="text"
+              value={deleteConfirm}
+              onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
+              data-testid="delete-confirm"
+              id="delete-confirm"
+            />
+            <Button
+              variant="secondary"
+              style={{
+                backgroundColor: "#AD1A1A",
+                color: "#FFF",
+                opacity: disabledDeprovisioning ? 0.5 : 1,
+              }}
+              disabled={disabledDeprovisioning}
+              className="h-15 w-60 mb-0 ml-4 flex"
+              onClick={deprovisionApp}
+            >
+              <IconTrash color="#FFF" className="mr-2" />
+              {isDeprovisioning ? "Deprovisioning..." : "Deprovision App"}
+            </Button>
+          </div>
+        </div>
+      </Box>
+    </div>
+  );
 };

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -1,7 +1,8 @@
 import { fetchApp, selectAppById } from "@app/deploy";
+import { deprovisionApp } from "@app/projects";
 import { AppState } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router";
 import { useQuery } from "saga-query/react";
 import {
@@ -17,13 +18,13 @@ import {
   Input,
   Label,
   PreCode,
-  tokens,
 } from "../shared";
 
 export const AppSettingsPage = () => {
   const [handle, setHandle] = useState<string>("");
   const [deleteConfirm, setDeleteConfirm] = useState<string>("");
   const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
+  const dispatch = useDispatch();
 
   const { id = "" } = useParams();
   useQuery(fetchApp({ id }));
@@ -37,16 +38,18 @@ export const AppSettingsPage = () => {
     e.preventDefault();
   };
 
-  const deprovisionApp = (e: SyntheticEvent) => {
+  const requestDeprovisionApp = (e: SyntheticEvent) => {
     e.preventDefault();
 
     setIsDeprovisioning(true);
+    dispatch(deprovisionApp({ appId: app.id }));
   };
 
-  const disabledDeprovisioning = isDeprovisioning || handle !== deleteConfirm;
+  const disabledDeprovisioning =
+    isDeprovisioning || "delete" !== deleteConfirm.toLocaleLowerCase();
 
   return (
-    <div>
+    <div className="mb-4">
       <Box>
         <Button className="relative float-right" variant="white">
           View Docs
@@ -54,15 +57,15 @@ export const AppSettingsPage = () => {
         </Button>
         <h1 className="text-lg text-gray-500">How To Deploy Changes</h1>
         <div className="mt-4">
-          <h3 className={tokens.type.h4}>Clone project code</h3>
+          <h3 className="text-base font-semibold">Clone project code</h3>
           <PreCode allowCopy>git clone {app.gitRepo}</PreCode>
         </div>
         <div className="mt-4">
-          <h3 className={tokens.type.h4}>Find project code</h3>
+          <h3 className="text-base font-semibold">Find project code</h3>
           <PreCode allowCopy>cd {app.handle}</PreCode>
         </div>
         <div className="mt-4">
-          <h3 className={tokens.type.h4}>Deploy code changes</h3>
+          <h3 className="text-base font-semibold">Deploy code changes</h3>
           <PreCode allowCopy>git push {app.gitRepo}</PreCode>
         </div>
       </Box>
@@ -70,7 +73,10 @@ export const AppSettingsPage = () => {
         <h1 className="text-lg text-gray-500">App Settings</h1>
         <br />
         <form onSubmit={onSubmitForm}>
-          <FormGroup label="App Name" htmlFor="input-name">
+          <FormGroup label={""} htmlFor="input-name">
+            <Label className="text-base font-semibold text-gray-900 block">
+              App Name
+            </Label>
             <Input
               name="app-handle"
               type="text"
@@ -81,12 +87,17 @@ export const AppSettingsPage = () => {
               id="input-name"
             />
           </FormGroup>
-          <Label className="my-4">App ID</Label>
+          <Label className="text-base mt-4 font-semibold text-gray-900 block">
+            App ID
+          </Label>
           <p>
             {app.id} <IconCopy className="inline h-4" color="#888C90" />
           </p>
           <div className="mt-4 flex" />
-          <FormGroup label="Thumbnail Image" htmlFor="thumbnail">
+          <FormGroup label="" htmlFor="thumbnail">
+            <Label className="text-base font-semibold text-gray-900 block">
+              Thumbnail Image
+            </Label>
             <div className="flex justify-between items-center">
               <select
                 onChange={() => {}}
@@ -101,10 +112,10 @@ export const AppSettingsPage = () => {
               </select>
             </div>
           </FormGroup>
-          <FormGroup
-            label="Environment Variables"
-            htmlFor="environment-variables"
-          >
+          <FormGroup label="" htmlFor="environment-variables">
+            <Label className="text-base font-semibold text-gray-900 block">
+              Environment Variables
+            </Label>
             <div className="flex">
               <Input
                 className="flex w-1/2"
@@ -162,7 +173,7 @@ export const AppSettingsPage = () => {
         </form>
       </Box>
       <Box>
-        <h1 className="text-lg text-red-500">
+        <h1 className="text-lg text-red-500 font-semibold">
           <IconAlertTriangle
             className="inline pr-3 mb-1"
             style={{ width: 32 }}
@@ -196,7 +207,7 @@ export const AppSettingsPage = () => {
               }}
               disabled={disabledDeprovisioning}
               className="h-15 w-60 mb-0 ml-4 flex"
-              onClick={deprovisionApp}
+              onClick={requestDeprovisionApp}
             >
               <IconTrash color="#FFF" className="mr-2" />
               {isDeprovisioning ? "Deprovisioning..." : "Deprovision App"}

--- a/src/ui/pages/app-detail-settings.tsx
+++ b/src/ui/pages/app-detail-settings.tsx
@@ -72,10 +72,7 @@ export const AppSettingsPage = () => {
         <h1 className="text-lg text-gray-500">App Settings</h1>
         <br />
         <form onSubmit={onSubmitForm}>
-          <FormGroup label={""} htmlFor="input-name">
-            <Label className="text-base font-semibold text-gray-900 block">
-              App Name
-            </Label>
+          <FormGroup label="App Name" htmlFor="input-name">
             <Input
               name="app-handle"
               type="text"
@@ -93,13 +90,9 @@ export const AppSettingsPage = () => {
             {app.id} <IconCopy className="inline h-4" color="#888C90" />
           </p>
           <div className="mt-4 flex" />
-          <FormGroup label="" htmlFor="thumbnail">
-            <Label className="text-base font-semibold text-gray-900 block">
-              Thumbnail Image
-            </Label>
+          <FormGroup label="Thumbnail Image" htmlFor="thumbnail">
             <div className="flex justify-between items-center">
               <select
-                onChange={() => {}}
                 value={"test"}
                 className="mb-2"
                 placeholder="select"
@@ -111,10 +104,10 @@ export const AppSettingsPage = () => {
               </select>
             </div>
           </FormGroup>
-          <FormGroup label="" htmlFor="environment-variables">
-            <Label className="text-base font-semibold text-gray-900 block">
-              Environment Variables
-            </Label>
+          <FormGroup
+            label="Environment Variables"
+            htmlFor="environment-variables"
+          >
             <div className="flex">
               <Input
                 className="flex w-1/2"

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -334,11 +334,11 @@ export const CreateProjectGitPushPage = () => {
       <Box>
         <div>
           <h3 className={tokens.type.h3}>Add Aptible's Git Server</h3>
-          <PreCode>git remote add aptible {app.gitRepo}</PreCode>
+          <PreCode text={["git", "remote", "add", "aptible", app.gitRepo]} />
         </div>
         <div className="mt-4">
           <h3 className={tokens.type.h3}>Push your code to our scan branch</h3>
-          <PreCode>git push aptible main:aptible-scan</PreCode>
+          <PreCode text={["git", "push", "aptible", "main:aptible-scan"]} />
         </div>
 
         <hr className="my-4" />
@@ -1451,7 +1451,7 @@ export const CreateProjectGitStatusPage = () => {
           Commit changes to your local git repo and push to the Aptible git
           server.
         </p>
-        <PreCode>git push aptible main</PreCode>
+        <PreCode text={["git", "push", "aptible", "main"]} />
         <hr />
 
         <ButtonLink to={appOverviewUrl(appId)} className="mt-4 mb-2">

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -55,6 +55,7 @@ import {
   IconX,
   IconArrowRight,
   IconPlusCircle,
+  PreCode,
 } from "../shared";
 import { AddSSHKeyForm } from "../shared/add-ssh-key";
 import {
@@ -202,10 +203,6 @@ export const CreateProjectAddKeyPage = () => {
       </Box>
     </div>
   );
-};
-
-const PreCode = ({ children }: { children: React.ReactNode }) => {
-  return <pre className={tokens.type.pre}>{children}</pre>;
 };
 
 export const CreateProjectNamePage = () => {

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -334,11 +334,17 @@ export const CreateProjectGitPushPage = () => {
       <Box>
         <div>
           <h3 className={tokens.type.h3}>Add Aptible's Git Server</h3>
-          <PreCode text={["git", "remote", "add", "aptible", app.gitRepo]} />
+          <PreCode
+            text={["git", "remote", "add", "aptible", app.gitRepo]}
+            allowCopy
+          />
         </div>
         <div className="mt-4">
           <h3 className={tokens.type.h3}>Push your code to our scan branch</h3>
-          <PreCode text={["git", "push", "aptible", "main:aptible-scan"]} />
+          <PreCode
+            text={["git", "push", "aptible", "main:aptible-scan"]}
+            allowCopy
+          />
         </div>
 
         <hr className="my-4" />
@@ -1451,7 +1457,7 @@ export const CreateProjectGitStatusPage = () => {
           Commit changes to your local git repo and push to the Aptible git
           server.
         </p>
-        <PreCode text={["git", "push", "aptible", "main"]} />
+        <PreCode text={["git", "push", "aptible", "main"]} allowCopy />
         <hr />
 
         <ButtonLink to={appOverviewUrl(appId)} className="mt-4 mb-2">

--- a/src/ui/pages/create-project-git.tsx
+++ b/src/ui/pages/create-project-git.tsx
@@ -14,7 +14,7 @@ import cn from "classnames";
 
 import { prettyDateRelative, prettyDateTime } from "@app/date";
 import {
-  appDetailUrl,
+  appOverviewUrl,
   createProjectAddKeyUrl,
   createProjectAddNameUrl,
   createProjectGitPushUrl,
@@ -1454,7 +1454,7 @@ export const CreateProjectGitStatusPage = () => {
         <PreCode>git push aptible main</PreCode>
         <hr />
 
-        <ButtonLink to={appDetailUrl(appId)} className="mt-4 mb-2">
+        <ButtonLink to={appOverviewUrl(appId)} className="mt-4 mb-2">
           View Project <IconArrowRight variant="sm" className="ml-2" />
         </ButtonLink>
       </StatusBox>

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -73,13 +73,9 @@ export const DatabaseSettingsPage = () => {
             {database.id} <IconCopy className="inline h-4" color="#888C90" />
           </p>
           <div className="mt-4 flex" />
-          <FormGroup label="" htmlFor="thumbnail">
-            <Label className="text-base font-semibold text-gray-900 block">
-              Thumbnail Image
-            </Label>
+          <FormGroup label="Thumbnail Image" htmlFor="thumbnail">
             <div className="flex justify-between items-center mb-4">
               <select
-                onChange={() => {}}
                 value={"test"}
                 className="mb-2"
                 placeholder="select"

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -1,5 +1,4 @@
-import { selectDatabaseById } from "@app/deploy";
-import { deprovisionDatabase } from "@app/projects";
+import { deprovisionDatabase, selectDatabaseById } from "@app/deploy";
 import { AppState } from "@app/types";
 import { SyntheticEvent, useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -78,7 +77,7 @@ export const DatabaseSettingsPage = () => {
             <Label className="text-base font-semibold text-gray-900 block">
               Thumbnail Image
             </Label>
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center mb-4">
               <select
                 onChange={() => {}}
                 value={"test"}
@@ -90,6 +89,19 @@ export const DatabaseSettingsPage = () => {
                   Some Icon
                 </option>
               </select>
+            </div>
+            <hr />
+            <div className="flex mt-4">
+              <Button className="w-40 mb-4 flex" onClick={() => {}}>
+                Save Changes
+              </Button>
+              <Button
+                className="w-40 ml-4 mb-4 flex"
+                onClick={() => {}}
+                variant="white"
+              >
+                Cancel
+              </Button>
             </div>
           </FormGroup>
         </form>

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -1,3 +1,143 @@
+import { selectDatabaseById } from "@app/deploy";
+import { deprovisionDatabase } from "@app/projects";
+import { AppState } from "@app/types";
+import { SyntheticEvent, useEffect, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { useParams } from "react-router";
+import {
+  Box,
+  Button,
+  FormGroup,
+  IconAlertTriangle,
+  IconCopy,
+  IconExternalLink,
+  IconTrash,
+  Input,
+  Label,
+} from "../shared";
+
 export const DatabaseSettingsPage = () => {
-  return <div>Database settings page</div>;
+  const { id = "" } = useParams();
+  const [deleteConfirm, setDeleteConfirm] = useState<string>("");
+  const [handle, setHandle] = useState<string>("");
+  const [isDeprovisioning, setIsDeprovisioning] = useState<boolean>(false);
+
+  const dispatch = useDispatch();
+  const database = useSelector((s: AppState) => selectDatabaseById(s, { id }));
+
+  useEffect(() => {
+    setHandle(database.handle);
+  }, [database?.id]);
+
+  const onSubmitForm = (e: SyntheticEvent) => {
+    e.preventDefault();
+  };
+
+  const requestDeprovisionDatabase = (e: SyntheticEvent) => {
+    e.preventDefault();
+
+    setIsDeprovisioning(true);
+    dispatch(deprovisionDatabase({ dbId: database.id }));
+  };
+
+  const disabledDeprovisioning =
+    isDeprovisioning || "delete" !== deleteConfirm.toLocaleLowerCase();
+
+  return (
+    <div className="mb-4">
+      <Box>
+        <Button className="relative float-right" variant="white">
+          View Docs
+          <IconExternalLink className="inline ml-3 h-5 mt-0" />
+        </Button>
+        <h1 className="text-lg text-gray-500">Database Settings</h1>
+        <br />
+        <form onSubmit={onSubmitForm}>
+          <FormGroup label={""} htmlFor="input-name">
+            <Label className="text-base font-semibold text-gray-900 block">
+              Database Name
+            </Label>
+            <Input
+              name="app-handle"
+              type="text"
+              value={handle}
+              onChange={(e) => setHandle(e.currentTarget.value)}
+              autoComplete="name"
+              data-testid="input-name"
+              id="input-name"
+            />
+          </FormGroup>
+          <Label className="text-base mt-4 font-semibold text-gray-900 block">
+            Database ID
+          </Label>
+          <p>
+            {database.id} <IconCopy className="inline h-4" color="#888C90" />
+          </p>
+          <div className="mt-4 flex" />
+          <FormGroup label="" htmlFor="thumbnail">
+            <Label className="text-base font-semibold text-gray-900 block">
+              Thumbnail Image
+            </Label>
+            <div className="flex justify-between items-center">
+              <select
+                onChange={() => {}}
+                value={"test"}
+                className="mb-2"
+                placeholder="select"
+                disabled
+              >
+                <option value="test" disabled>
+                  Some Icon
+                </option>
+              </select>
+            </div>
+          </FormGroup>
+        </form>
+      </Box>
+
+      <Box>
+        <h1 className="text-lg text-red-500 font-semibold">
+          <IconAlertTriangle
+            className="inline pr-3 mb-1"
+            style={{ width: 32 }}
+            color="#AD1A1A"
+          />
+          Deprovision Database
+        </h1>
+        <div className="mt-2">
+          <p>
+            This will permanently deprovision <strong>{database.handle}</strong>{" "}
+            database. This action cannot be undone. If you want to proceed, type
+            Delete below to continue.
+          </p>
+          <div className="flex mt-4 wd-60">
+            <Input
+              className="flex"
+              disabled={isDeprovisioning}
+              name="delete-confirm"
+              type="text"
+              value={deleteConfirm}
+              onChange={(e) => setDeleteConfirm(e.currentTarget.value)}
+              data-testid="delete-confirm"
+              id="delete-confirm"
+            />
+            <Button
+              variant="secondary"
+              style={{
+                backgroundColor: "#AD1A1A",
+                color: "#FFF",
+                opacity: disabledDeprovisioning ? 0.5 : 1,
+              }}
+              disabled={disabledDeprovisioning}
+              className="h-15 w-70 mb-0 ml-4 flex"
+              onClick={requestDeprovisionDatabase}
+            >
+              <IconTrash color="#FFF" className="mr-2" />
+              {isDeprovisioning ? "Deprovisioning..." : "Deprovision Database"}
+            </Button>
+          </div>
+        </div>
+      </Box>
+    </div>
+  );
 };

--- a/src/ui/pages/db-detail-settings.tsx
+++ b/src/ui/pages/db-detail-settings.tsx
@@ -26,7 +26,7 @@ export const DatabaseSettingsPage = () => {
 
   useEffect(() => {
     setHandle(database.handle);
-  }, [database?.id]);
+  }, [database.id]);
 
   const onSubmitForm = (e: SyntheticEvent) => {
     e.preventDefault();

--- a/src/ui/shared/app/app-list.tsx
+++ b/src/ui/shared/app/app-list.tsx
@@ -14,7 +14,7 @@ import {
 import type { AppState } from "@app/types";
 import { selectServicesByIds } from "@app/deploy";
 import { calcMetrics } from "@app/deploy";
-import { appDetailUrl } from "@app/routes";
+import { appOverviewUrl } from "@app/routes";
 
 import { TableHead, Td } from "../table";
 import { LoadResources } from "../load-resources";
@@ -29,7 +29,7 @@ interface AppCellProps {
 const AppPrimaryCell = ({ app }: AppCellProps) => {
   return (
     <Td className="flex-1">
-      <Link to={appDetailUrl(app.id)}>
+      <Link to={appOverviewUrl(app.id)}>
         <div className={tokens.type["medium label"]}>{app.handle}</div>
         <div className={tokens.type["normal lighter"]}>{app.envHandle}</div>
       </Link>

--- a/src/ui/shared/application-sidebar.tsx
+++ b/src/ui/shared/application-sidebar.tsx
@@ -5,7 +5,7 @@ import { IconLayers, IconBox, IconPlusCircle, IconGlobe } from "@app/ui/shared";
 import {
   appsUrl,
   createProjectUrl,
-  databasesUrl,
+  databaseUrl,
   environmentsUrl,
 } from "@app/routes";
 import { ButtonIcon } from "./button";
@@ -17,7 +17,7 @@ export const ApplicationSidebar = () => {
   const navigation = [
     { name: "Environments", to: environmentsUrl(), icon: <IconGlobe /> },
     { name: "Apps", to: appsUrl(), icon: <IconLayers /> },
-    { name: "Databases", to: databasesUrl(), icon: <IconBox /> },
+    { name: "Databases", to: databaseUrl(), icon: <IconBox /> },
   ];
 
   return (

--- a/src/ui/shared/breadcrumbs.tsx
+++ b/src/ui/shared/breadcrumbs.tsx
@@ -3,26 +3,31 @@ import { NavLink } from "react-router-dom";
 import { tokens } from "./tokens";
 
 export type Crumb = {
-  name: string;
+  name: string | null;
   to: string;
 };
 
 const navLink = ({ isActive }: { isActive: boolean }) =>
   cn(
-    "flex items-center",
+    "text-xl flex items-center",
     { [tokens.type.link]: !isActive },
-    { [tokens.type["subdued active link"]]: isActive },
+    { [tokens.type.link]: isActive },
   );
 
 export function Breadcrumbs({ crumbs }: { crumbs: Crumb[] }) {
   return (
     <nav className="flex" aria-label="Breadcrumb">
       <ol className="flex items-center">
-        {crumbs.map((crumb) => (
+        {crumbs.map((crumb, idx) => (
           <li key={crumb.name}>
-            <NavLink className={navLink} to={crumb.to}>
-              {crumb.name}
-            </NavLink>
+            {crumb.to === null ? (
+              <div className="text-xl">&nbsp;{crumb.name}</div>
+            ) : (
+              <NavLink className={navLink} to={crumb.to}>
+                {" "}
+                {crumb.name} {idx !== crumbs.length && "/"}
+              </NavLink>
+            )}
           </li>
         ))}
       </ol>

--- a/src/ui/shared/breadcrumbs.tsx
+++ b/src/ui/shared/breadcrumbs.tsx
@@ -3,8 +3,8 @@ import { NavLink } from "react-router-dom";
 import { tokens } from "./tokens";
 
 export type Crumb = {
-  name: string | null;
-  to: string;
+  name: string;
+  to: string | null;
 };
 
 const navLink = ({ isActive }: { isActive: boolean }) =>

--- a/src/ui/shared/db/database-list.tsx
+++ b/src/ui/shared/db/database-list.tsx
@@ -18,13 +18,14 @@ import { tokens } from "../tokens";
 import { ResourceHeader, ResourceListView } from "../resource-list-view";
 import { InputSearch } from "../input";
 import { LoadResources } from "../load-resources";
+import { databaseOverviewUrl } from "@app/routes";
 
 type DatabaseCellProps = { database: DeployDatabase };
 
 const DatabasePrimaryCell = ({ database }: DatabaseCellProps) => {
   return (
     <Td className="flex-1">
-      <Link to={`/databases/${database.id}`}>
+      <Link to={databaseOverviewUrl(database.id)}>
         <div className={tokens.type["medium label"]}>{database.handle}</div>
         <div className={tokens.type["normal lighter"]}>{database.type}</div>
       </Link>

--- a/src/ui/shared/detail-page-header-view.tsx
+++ b/src/ui/shared/detail-page-header-view.tsx
@@ -8,7 +8,7 @@ type HeaderProps = {
   breadcrumbs?: Crumb[];
   actions?: ActionList;
   detailsBox?: React.ReactNode;
-  title: Element;
+  title: string;
   tabs: TabItem[];
 };
 
@@ -22,19 +22,18 @@ export const DetailPageHeaderView = ({
   return (
     <div className={cn("bg-white", "border-black-200", "border-b")}>
       <div className={cn(tokens.layout["main width"], "pt-8")}>
-        {breadcrumbs && <Breadcrumbs crumbs={breadcrumbs} />}
+        {breadcrumbs && (
+          <Breadcrumbs crumbs={[...breadcrumbs, { to: null, name: title }]} />
+        )}
       </div>
 
-      <div className={cn("border-black-100", "border-b")}>
-        <div
-          className={cn(
-            tokens.layout["main width"],
-            "pb-6 pt-0 flex items-center",
-          )}
-        >
-          <div className={cn(tokens.type.h1, "flex-1")}>{title}</div>
-          {actions && <ActionListView actions={actions} />}
-        </div>
+      <div
+        className={cn(
+          tokens.layout["main width"],
+          "pb-0 pt-0 flex items-center",
+        )}
+      >
+        {actions && <ActionListView actions={actions} />}
       </div>
 
       {detailsBox ? detailsBox : null}

--- a/src/ui/shared/detail-page-header-view.tsx
+++ b/src/ui/shared/detail-page-header-view.tsx
@@ -7,6 +7,7 @@ type Element = JSX.Element | React.ReactNode;
 type HeaderProps = {
   breadcrumbs?: Crumb[];
   actions?: ActionList;
+  detailsBox?: React.ReactNode;
   title: Element;
   tabs: TabItem[];
 };
@@ -14,6 +15,7 @@ type HeaderProps = {
 export const DetailPageHeaderView = ({
   breadcrumbs,
   title,
+  detailsBox,
   actions,
   tabs,
 }: HeaderProps) => {
@@ -34,6 +36,8 @@ export const DetailPageHeaderView = ({
           {actions && <ActionListView actions={actions} />}
         </div>
       </div>
+
+      {detailsBox ? detailsBox : null}
 
       {tabs && (
         <div className={cn(tokens.layout["main width"], "pt-1")}>

--- a/src/ui/shared/icons.tsx
+++ b/src/ui/shared/icons.tsx
@@ -177,22 +177,22 @@ export const IconXCircle = (props: Props) => {
   );
 };
 
-export const IconAlertTriangle = (props: Props) => {
-  return (
-    <IconStrokeBase {...props}>
-      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-      <line x1="12" y1="9" x2="12" y2="13" />
-      <line x1="12" y1="17" x2="12.01" y2="17" />
-    </IconStrokeBase>
-  );
-};
-
 export const IconAlertCircle = (props: Props) => {
   return (
     <IconStrokeBase {...props}>
       <circle cx="12" cy="12" r="10" />
       <line x1="12" y1="8" x2="12" y2="12" />
       <line x1="12" y1="16" x2="12.01" y2="16" />
+    </IconStrokeBase>
+  );
+};
+
+export const IconAlertTriangle = (props: Props) => {
+  return (
+    <IconStrokeBase {...props}>
+      <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
     </IconStrokeBase>
   );
 };
@@ -263,6 +263,25 @@ export const IconEllipsis = (props: Props) => {
       <circle cx="12" cy="12" r="1" />
       <circle cx="19" cy="12" r="1" />
       <circle cx="5" cy="12" r="1" />
+    </IconStrokeBase>
+  );
+};
+
+export const IconExternalLink = (props: Props) => {
+  return (
+    <IconStrokeBase {...props}>
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </IconStrokeBase>
+  );
+};
+
+export const IconCopy = (props: Props) => {
+  return (
+    <IconStrokeBase {...props}>
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
     </IconStrokeBase>
   );
 };

--- a/src/ui/shared/index.ts
+++ b/src/ui/shared/index.ts
@@ -32,3 +32,4 @@ export * from "./verify-email";
 export * from "./modal-portal";
 export * from "./icons";
 export * from "./box";
+export * from "./pre-code";

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -21,6 +21,7 @@ export const PreCode = ({
           color="#888C90"
           className="mt-4 mr-4 float-right"
           onClick={handleCopy}
+          style={{ cursor: "pointer" }}
         />
       ) : null}
       <pre className={`${tokens.type.pre} text-sm pr-14`}>

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -23,7 +23,7 @@ export const PreCode = ({
           onClick={handleCopy}
         />
       ) : null}
-      <pre className={`${tokens.type.pre} pr-14`}>{children}</pre>
+      <pre className={`${tokens.type.pre} text-sm pr-14`}>{children}</pre>
     </>
   );
 };

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -5,11 +5,13 @@ import { tokens } from "./tokens";
 export const PreCode = ({
   children,
   allowCopy = false,
+  // TODO - do we want to allow softwrap
 }: { children: React.ReactNode; allowCopy?: boolean }) => {
   const handleCopy = (e: SyntheticEvent) => {
     e.preventDefault();
     // TODO - THIS DOES NOT WORK PROPERLY WITHOUT UTIL/DEP
-    navigator.clipboard.writeText(children?.toString() ?? "");
+    // navigator.clipboard.writeText(children?.toString() ?? "");
+    console.log("wanting to copy data from target event", e);
   };
 
   return (

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -3,15 +3,15 @@ import { IconCopy } from "./icons";
 import { tokens } from "./tokens";
 
 export const PreCode = ({
-  children,
   allowCopy = false,
-  // TODO - do we want to allow softwrap
-}: { children: React.ReactNode; allowCopy?: boolean }) => {
+  text, // TODO - do we want to do this
+}: {
+  allowCopy?: boolean;
+  text: string[];
+}) => {
   const handleCopy = (e: SyntheticEvent) => {
     e.preventDefault();
-    // TODO - THIS DOES NOT WORK PROPERLY WITHOUT UTIL/DEP
-    // navigator.clipboard.writeText(children?.toString() ?? "");
-    console.log("wanting to copy data from target event", e);
+    navigator.clipboard.writeText(text.join(" "));
   };
 
   return (
@@ -23,7 +23,18 @@ export const PreCode = ({
           onClick={handleCopy}
         />
       ) : null}
-      <pre className={`${tokens.type.pre} text-sm pr-14`}>{children}</pre>
+      <pre className={`${tokens.type.pre} text-sm pr-14`}>
+        {text.map((textElem, idx) => {
+          const lastElement = idx === text.length - 1;
+          const highlightedText = lastElement ? "" : "text-lime";
+          return (
+            <span key={`${idx}-${textElem}`} className={highlightedText}>
+              {textElem}
+              {!lastElement && " "}
+            </span>
+          );
+        })}
+      </pre>
     </>
   );
 };

--- a/src/ui/shared/pre-code.tsx
+++ b/src/ui/shared/pre-code.tsx
@@ -1,0 +1,27 @@
+import { SyntheticEvent } from "react";
+import { IconCopy } from "./icons";
+import { tokens } from "./tokens";
+
+export const PreCode = ({
+  children,
+  allowCopy = false,
+}: { children: React.ReactNode; allowCopy?: boolean }) => {
+  const handleCopy = (e: SyntheticEvent) => {
+    e.preventDefault();
+    // TODO - THIS DOES NOT WORK PROPERLY WITHOUT UTIL/DEP
+    navigator.clipboard.writeText(children?.toString() ?? "");
+  };
+
+  return (
+    <>
+      {allowCopy ? (
+        <IconCopy
+          color="#888C90"
+          className="mt-4 mr-4 float-right"
+          onClick={handleCopy}
+        />
+      ) : null}
+      <pre className={`${tokens.type.pre} pr-14`}>{children}</pre>
+    </>
+  );
+};

--- a/src/ui/shared/tabs.tsx
+++ b/src/ui/shared/tabs.tsx
@@ -22,7 +22,7 @@ const navLink = ({ isActive }: { isActive: boolean }) =>
       [tokens.type.link]: !isActive,
       "border-transparent  hover:border-gray-300": "!isActive",
       [tokens.type["subdued active link"]]: isActive,
-      "border-emerald-500": isActive,
+      "border-amber-500": isActive,
     },
     "whitespace-nowrap py-4 px-1 border-b-2",
   );

--- a/src/ui/shared/tabs.tsx
+++ b/src/ui/shared/tabs.tsx
@@ -19,12 +19,12 @@ const navLink = ({ isActive }: { isActive: boolean }) =>
   cn(
     "flex items-center",
     {
-      [tokens.type.link]: !isActive,
+      "font-normal text-base text-gray-500 hover:text-gray-700": !isActive,
       "border-transparent  hover:border-gray-300": "!isActive",
-      [tokens.type["subdued active link"]]: isActive,
-      "border-amber-500": isActive,
+      "font-semibold": isActive,
+      "border-orange-400": isActive,
     },
-    "whitespace-nowrap py-4 px-1 border-b-2",
+    "whitespace-nowrap py-4 px-1 border-b-3",
   );
 
 export const Tab = ({ label, to }: TabViewProps) => (

--- a/src/ui/shared/tabs.tsx
+++ b/src/ui/shared/tabs.tsx
@@ -20,7 +20,7 @@ const navLink = ({ isActive }: { isActive: boolean }) =>
     "flex items-center",
     {
       "font-normal text-base text-gray-500 hover:text-gray-700": !isActive,
-      "border-transparent  hover:border-gray-300": "!isActive",
+      "border-transparent  hover:border-gray-300": !isActive,
       "font-semibold": isActive,
       "border-orange-400": isActive,
     },

--- a/src/ui/shared/tokens.ts
+++ b/src/ui/shared/tokens.ts
@@ -12,7 +12,7 @@ export const tokens = {
     link: "font-medium text-sm text-gray-500 hover:text-gray-700",
 
     "active link": "font-medium text-sm text-gray-700",
-    "subdued active link": "font-medium text-sm text-emerald-600",
+    "subdued active link": "font-medium text-sm text-amber-600",
 
     "small semibold darker": "text-sm font-semibold text-gray-900",
     "small normal darker": "text-sm font-normal text-gray-900",

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -7,6 +7,15 @@ module.exports = {
   darkMode: "class",
   theme: {
     extend: {
+      borderWidth: {
+        DEFAULT: '1px',
+        '0': '0',
+        '2': '2px',
+        '3': '3px',
+        '4': '4px',
+        '6': '6px',
+        '8': '8px',
+      },
       fontSize: {
         sm: ["12px", "20px"],
         base: ["14px", "20px"],
@@ -14,6 +23,7 @@ module.exports = {
         lg: ["20px", "28px"],
         xl: ["24px", "32px"],
       },
+      
       fontFamily: {
         sans: [...defaultTheme.fontFamily.sans],
         serif: [...defaultTheme.fontFamily.serif],

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,13 +8,13 @@ module.exports = {
   theme: {
     extend: {
       borderWidth: {
-        DEFAULT: '1px',
-        '0': '0',
-        '2': '2px',
-        '3': '3px',
-        '4': '4px',
-        '6': '6px',
-        '8': '8px',
+        DEFAULT: "1px",
+        0: "0",
+        2: "2px",
+        3: "3px",
+        4: "4px",
+        6: "6px",
+        8: "8px",
       },
       fontSize: {
         sm: ["12px", "20px"],
@@ -23,7 +23,7 @@ module.exports = {
         lg: ["20px", "28px"],
         xl: ["24px", "32px"],
       },
-      
+
       fontFamily: {
         sans: [...defaultTheme.fontFamily.sans],
         serif: [...defaultTheme.fontFamily.serif],


### PR DESCRIPTION
* This adds a common component that is sort-of reused in both app/database pages
* This allows for deprovisioning of an app/database (and it looks to work!, though I need to check with Josh on some of it as some operations failed with rollback failed)
* Cleans up some tab behavior (I will likely need to talk to you about this Eric as this alters the index behavior)

Edit - can update to include screenshots but I think e2e testing or something deprovisioned my testing stack and I'll probably test against it in the morn for a fresh batch. It looks pretty close to the current mocks though! (Screenshot a bit below but that's slightly outdated)

app management:
<img width="1259" alt="image" src="https://user-images.githubusercontent.com/2961973/227536692-8ac5e0b4-ceb7-4170-a283-11fb4e8af0cc.png">

db management:
<img width="1271" alt="image" src="https://user-images.githubusercontent.com/2961973/227536749-33f645c2-ec87-4f89-af20-5eb1bc06b20b.png">
